### PR TITLE
Atualizar README com contexto e suíte de testes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,91 +1,51 @@
-# 📦 .github Repository
+# TraceSQL
 
-> 🧰 Modelo base para repositórios com padronizações e boas práticas, como templates de issues, workflows, licenças e mais.
----
+Suite de ferramentas para inspecionar e exportar dados relacionais (MySQL, PostgreSQL e bancos em arquivo). A visão de longo prazo inclui uma extensão VS Code; começamos por um utilitário de terminal multiplataforma.
 
-## English
+## Fase 1 – CLI de exportação
+- Alvo: Windows, Linux e macOS, distribuído como artefato na página de Releases do GitHub.
+- Entrada: conexão via variáveis de ambiente (.env) ou parâmetros no prompt.
+- Fluxo: perguntar tabela origem, perguntar coluna de referência (padrão `id` se omitir), mapear tabelas relacionadas (referências e referenciadas) e exportar todos os registros ligados.
+- Saída: arquivo `.sql` que insere todos os dados exportados. Começa preservando IDs; no futuro, suportará geração de novos IDs.
 
-This is a **template repository** used to centralize and standardize configuration files across multiple GitHub projects.
+## Roadmap resumido
+1) Script CLI de exportação (atual).  
+2) Bibliotecar lógica de relacionamento/export para reuso.  
+3) Extensão VS Code consumindo a biblioteca.  
+4) Automatizar publicações em Release.
 
-It includes common files like:
+## Requisitos funcionais
+- Conexão com MySQL, PostgreSQL e SQLite.
+- Respeitar credenciais vindas de `.env` para evitar prompts repetitivos.
+- Descobrir relações (FKs) para trazer tabelas que referenciam ou são referenciadas.
+- Gerar SQL de insert idempotente para recriar dados exportados.
 
-- ✅ Issue templates
-- ⚙️ GitHub Actions workflows
-- 📄 License
-- 🏷️ Label configuration
-- 💰 Funding metadata
+## Suite de testes recomendada
+- Linguagem sugerida para a CLI: Python 3.11+ (portabilidade e drivers maduros).
+- Testes unitários: `pytest` com `coverage` para parsing, conexão e geração de SQL.
+- Testes de integração por banco: `pytest` + `docker-compose` subindo MySQL, PostgreSQL e SQLite (local). Usar marcadores `@pytest.mark.mysql`/`postgres`/`sqlite`.
+- Testes end-to-end: invocar o CLI com `.env` de exemplo e validar o arquivo `.sql` gerado.
+- Matriz CI: GitHub Actions com jobs paralelos por SO (ubuntu-22.04, windows-2022, macos-14) e serviços Docker para MySQL/Postgres.
+- Linters/qualidade: `ruff` (lint+fmt) e `mypy` para contratos de conexão e modelos de metadados.
 
-### 🔧 How to Use
-
-1. Click **"Use this template"** on GitHub
-2. Or clone manually:
-
-```bash
-git clone https://github.com/Felipe-Cavalca/.github.git
+## Estrutura inicial sugerida
+```
+src/
+  tracesql/
+    cli.py           # entrada do comando
+    exporters.py     # geração de INSERTs
+    metadata.py      # descoberta de FKs e relações
+    settings.py      # leitura de .env / args
+tests/
+  unit/
+  integration/
+  e2e/
+.env.example
+docker-compose.yml   # serviços MySQL/PostgreSQL para integração
 ```
 
-### 📁 Project Structure
-```
-.github/
-├── ISSUE_TEMPLATE/       # Issue templates
-├── workflows/            # GitHub Actions workflows
-├── FUNDING.yml           # Funding metadata
-├── labels.yml            # Label configuration
-└── PULL_REQUEST_TEMPLATE.md
-
-.vscode/
-├── extensions.json        # Recommended VSCode extensions
-└── tasks.json             # VSCode tasks
-
-LICENSE                   # Project license
-README.md                 # This README
-SECURITY.md               # Security policy
-```
-
-### 📌 Versions
-[👉 Releases](https://github.com/Felipe-Cavalca/.github/releases)
-
----
-
-## Português
-
-Este é um **repositório modelo** criado para centralizar e padronizar arquivos de configuração usados em diversos projetos no GitHub.
-
-Ele inclui:
-
- - ✅ Templates de issues
- - ⚙️ Workflows do GitHub Actions
- - 📄 Licença
- - 🏷️ Configuração de labels
- - 💰 Metadados de financiamento
-
-### 🔧 Como Usar
-
-Clique em "Use this template" no GitHub
-
-Ou clone manualmente:
-```bash
-git clone https://github.com/Felipe-Cavalca/.github.git
-```
-
-### 📁 Estrutura do Projeto
-
-```
-.github/
-├── ISSUE_TEMPLATE/       # Templates de issues
-├── workflows/            # Workflows do GitHub Actions
-├── FUNDING.yml           # Metadados de financiamento
-├── labels.yml            # Configuração de labels
-└── PULL_REQUEST_TEMPLATE.md
-
-.vscode/
-├── extensions.json        # Extensões recomendadas para VSCode
-└── tasks.json             # Tarefas para VSCode
-
-LICENSE                   # Licença do projeto
-README.md                 # Este README
-```
-
-### 📌 Versões
-
-[👉 Releases no GitHub](https://github.com/Felipe-Cavalca/.github/releases)
+## Próximos passos
+- Confirmar linguagem (assumida Python) e criar esqueleto `src/` e `tests/`.
+- Adicionar `.env.example` com variáveis de conexão.
+- Configurar GitHub Actions com matriz de SO + bancos em serviços.
+- Publicar primeiro binário/zip na Release após o MVP do CLI.


### PR DESCRIPTION
## Resumo
- reescreve README com contexto do TraceSQL
- descreve Fase 1 (CLI de exportação) e roadmap resumido
- recomenda suíte de testes e matriz de CI

## Notas
- abordagem assumida: CLI em Python para portabilidade
- não há mudanças de código além do README