### PR TITLE
Bootstrap do CLI TraceSQL (skeleton)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Driver: mysql | postgres | sqlite
+TRACE_DRIVER=mysql
+
+# Conexão completa em formato DSN
+# MySQL:    TRACE_DSN=root:password@tcp(localhost:3306)/database
+# Postgres: TRACE_DSN=postgres://user:password@localhost:5432/database
+# SQLite:   TRACE_DSN=file:./database.sqlite
+TRACE_DSN=
+
+# Valores padrão (opcionais)
+TRACE_TABLE=
+TRACE_COLUMN=id

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Build artefacts
+bin/
+dist/
+*.exe
+
+# Env files
+.env

--- a/cmd/tracesql/main.go
+++ b/cmd/tracesql/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Felipe-Cavalca/TraceSQL/internal/config"
+	"github.com/Felipe-Cavalca/TraceSQL/internal/db"
+	"github.com/Felipe-Cavalca/TraceSQL/internal/export"
+)
+
+type options struct {
+	EnvPath string
+	Driver  string
+	DSN     string
+	Table   string
+	Column  string
+	Output  string
+}
+
+func main() {
+	log.SetFlags(0)
+
+	var opt options
+	flag.StringVar(&opt.EnvPath, "env", ".env", "caminho do arquivo .env")
+	flag.StringVar(&opt.Driver, "driver", "", "driver do banco: mysql | postgres | sqlite")
+	flag.StringVar(&opt.DSN, "dsn", "", "DSN de conexão (ou defina TRACE_DSN no .env)")
+	flag.StringVar(&opt.Table, "table", "", "tabela de origem")
+	flag.StringVar(&opt.Column, "column", "id", "coluna de referência (padrão: id)")
+	flag.StringVar(&opt.Output, "output", "export.sql", "arquivo de saída SQL")
+	flag.Parse()
+
+	_ = config.LoadEnv(opt.EnvPath) // se não existir, apenas ignora
+
+	prompt := bufio.NewReader(os.Stdin)
+
+	opt.Driver = firstNonEmpty(opt.Driver, os.Getenv("TRACE_DRIVER"))
+	if opt.Driver == "" {
+		opt.Driver = ask(prompt, "Driver (mysql|postgres|sqlite): ")
+	}
+	if err := config.ValidateDriver(opt.Driver); err != nil {
+		log.Fatalf("driver inválido: %v", err)
+	}
+
+	opt.DSN = firstNonEmpty(opt.DSN, os.Getenv("TRACE_DSN"))
+	if opt.DSN == "" {
+		opt.DSN = ask(prompt, "DSN de conexão: ")
+	}
+
+	opt.Table = firstNonEmpty(opt.Table, os.Getenv("TRACE_TABLE"))
+	if opt.Table == "" {
+		opt.Table = ask(prompt, "Tabela de origem: ")
+	}
+
+	opt.Column = firstNonEmpty(opt.Column, os.Getenv("TRACE_COLUMN"))
+	if opt.Column == "" {
+		opt.Column = "id"
+	}
+
+	log.Printf("Conectando via driver %s...", opt.Driver)
+	conn, closer, err := db.Connect(opt.Driver, opt.DSN)
+	if err != nil {
+		log.Fatalf("falha ao conectar: %v", err)
+	}
+	defer closer()
+
+	if err := conn.Ping(); err != nil {
+		log.Fatalf("ping falhou: %v", err)
+	}
+	log.Printf("Conexão OK.")
+
+	if err := export.WritePlaceholder(opt.Output, opt.Table, opt.Column, time.Now()); err != nil {
+		log.Fatalf("erro ao gerar export: %v", err)
+	}
+	log.Printf("Arquivo %s criado (placeholder). Próximo passo: implementar coleta de relações e INSERTs.", opt.Output)
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func ask(r *bufio.Reader, msg string) string {
+	fmt.Print(msg)
+	s, _ := r.ReadString('\n')
+	return strings.TrimSpace(s)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/Felipe-Cavalca/TraceSQL
+
+go 1.22
+
+require (
+	github.com/go-sql-driver/mysql v1.7.1
+	github.com/jackc/pgx/v5 v5.5.4
+	github.com/joho/godotenv v1.5.1
+	modernc.org/sqlite v1.27.0
+)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,29 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"strings"
+
+	"github.com/joho/godotenv"
+)
+
+// LoadEnv carrega variáveis do arquivo informado, se existir.
+func LoadEnv(path string) error {
+	if path == "" {
+		return nil
+	}
+	if _, err := os.Stat(path); err != nil {
+		return nil // silencioso quando não existe
+	}
+	return godotenv.Load(path)
+}
+
+func ValidateDriver(d string) error {
+	switch strings.ToLower(d) {
+	case "mysql", "postgres", "sqlite":
+		return nil
+	default:
+		return errors.New("use mysql | postgres | sqlite")
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -1,0 +1,38 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	// imports necessários para registrar os drivers
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	_ "modernc.org/sqlite"
+)
+
+// Connect abre a conexão de acordo com o driver e devolve uma função para fechar.
+func Connect(driver, dsn string) (*sql.DB, func(), error) {
+	driver = strings.ToLower(driver)
+
+	switch driver {
+	case "mysql":
+		// mysql driver registrado em init()
+	case "postgres":
+		driver = "pgx"
+	case "sqlite":
+		driver = "sqlite"
+	default:
+		return nil, func() {}, fmt.Errorf("driver não suportado: %s", driver)
+	}
+
+	db, err := sql.Open(driver, dsn)
+	if err != nil {
+		return nil, func() {}, err
+	}
+
+	closeFn := func() {
+		_ = db.Close()
+	}
+	return db, closeFn, nil
+}

--- a/internal/export/export.go
+++ b/internal/export/export.go
@@ -1,0 +1,20 @@
+package export
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// WritePlaceholder gera um arquivo SQL provisório para sinalizar que o fluxo funcionou.
+func WritePlaceholder(path, table, column string, now time.Time) error {
+	content := fmt.Sprintf(`-- TraceSQL export placeholder
+-- gerado em %s
+-- tabela: %s
+-- coluna de referência: %s
+
+-- TODO: implementar coleta de relações e inserts encadeados.
+`, now.Format(time.RFC3339), table, column)
+
+	return os.WriteFile(path, []byte(content), 0o644)
+}


### PR DESCRIPTION
## Resumo
- inicia estrutura do CLI TraceSQL
- adiciona .env.example e carregamento opcional
- cria stub de conexão (mysql/postgres/sqlite) e gera arquivo SQL placeholder

## Detalhes
- flags para driver, dsn, tabela, coluna e saída
- leitura interativa quando flags/env não fornecidos
- ainda não exporta dados; próximo passo é mapear relações e gerar INSERTs
