### PR TITLE
[codex] Adiciona exportação multi-banco com logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Suite de ferramentas para inspecionar e exportar dados relacionais (MySQL, Postg
 - Alvo: Windows, Linux e macOS, distribuído como binário único nas Releases do GitHub.
 - Linguagem escolhida: Go 1.22+ (binário estático, sem runtime externo e boa portabilidade).
 - Entrada: conexão via variáveis de ambiente (.env) ou parâmetros no prompt. Pergunta interativamente se algo estiver faltando.
-- Fluxo atual: escolher banco/tabela, coluna de referência (padrão `id`), registro a exportar e se os IDs devem ser preservados ou regenerados. Gera um `.sql` com o `INSERT` correspondente.
+- Fluxo atual: escolher banco/tabela, coluna de referência (padrão `id`), registro a exportar, o dialeto de saída e se os IDs devem ser preservados ou regenerados. Gera um `.sql` com `CREATE TABLE` + `INSERTs` do grafo relacionado.
 - Saída: arquivo `.sql` nomeado como `export_<tabela>_<registro>.sql` (ou caminho informado via flag/ENV).
 
 ## Roadmap resumido
@@ -18,8 +18,8 @@ Suite de ferramentas para inspecionar e exportar dados relacionais (MySQL, Postg
 ## Requisitos funcionais
 - Conexão com MySQL, PostgreSQL e SQLite.
 - Respeitar credenciais vindas de `.env` para evitar prompts repetitivos.
-- (Em progresso) Descobrir relações (FKs) para trazer tabelas relacionadas.
-- Gerar SQL de insert idempotente para recriar dados exportados, com opção de preservar IDs ou deixar o banco gerar novos.
+- Descobrir relações (FKs) em SQLite, PostgreSQL e MySQL para trazer registros relacionados.
+- Gerar SQL para recriar schema e dados exportados, inclusive com origem e destino em bancos diferentes.
 
 ## Stack técnica (Go)
 - Drivers: `pgx` (PostgreSQL), `go-sql-driver/mysql` e `glebarez/sqlite` (sem CGO).
@@ -51,6 +51,7 @@ configs/.env.example      # template de configuração
 1) Preencha `configs/.env.example` e salve como `.env` (ou exporte as variáveis):  
    - `TRACESQL_DRIVER` (postgres | mysql | sqlite)  
    - `TRACESQL_DSN` (ex.: `postgres://user:pass@localhost:5432/db`)  
+   - `TRACESQL_OUTPUT_DRIVER` (opcional: postgres | mysql | sqlite; padrão = mesmo driver da origem)  
    - `TRACESQL_NEW_IDS` (`true` para omitir a coluna de referência no INSERT)  
    - `TRACESQL_OUT` (opcional: caminho do arquivo de saída)  
 2) Rode `go run ./cmd/tracesql` ou o binário baixado. Campos ausentes (tabela/coluna/registro) serão perguntados no terminal.  

--- a/cmd/tracesql/main.go
+++ b/cmd/tracesql/main.go
@@ -19,39 +19,52 @@ func main() {
 	_ = godotenv.Load()
 
 	cfg := config.Default()
+	logf := func(format string, args ...interface{}) {
+		if !cfg.Log {
+			return
+		}
+		fmt.Fprintf(os.Stderr, "[tracesql] "+format+"\n", args...)
+	}
 
 	rootCmd := &cobra.Command{
 		Use:   "tracesql",
 		Short: "Exporta registros relacionais para um arquivo .sql",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := config.BindFlags(cmd, &cfg); err != nil {
 				return err
 			}
+			logf("configuração carregada: origem=%s destino=%s tabela=%s coluna=%s registro=%s new_ids=%t", cfg.Driver, cfg.OutputDriver, cfg.Table, cfg.Column, cfg.Record, cfg.NewIDs)
 
 			if err := prompt.FillMissing(&cfg, os.Stdin, os.Stdout); err != nil {
 				return err
 			}
+			logf("prompts concluídos")
 
 			if err := cfg.Validate(); err != nil {
 				return err
 			}
+			logf("configuração validada")
 
 			database, err := db.Open(cfg.Driver, cfg.DSN)
 			if err != nil {
 				return err
 			}
 			defer database.Close()
+			logf("conexão com banco aberta")
 
 			ctx := context.Background()
 			sqlDump, err := export.Run(ctx, database, cfg)
 			if err != nil {
 				return err
 			}
+			logf("exportação concluída, %d bytes gerados", len(sqlDump))
 
 			outPath := cfg.OutPath()
 			if err := os.WriteFile(outPath, []byte(sqlDump), 0o644); err != nil {
 				return fmt.Errorf("gravando arquivo %s: %w", outPath, err)
 			}
+			logf("arquivo gravado em %s", outPath)
 
 			fmt.Fprintf(os.Stdout, "Arquivo gerado: %s\n", outPath)
 			return nil

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/glebarez/go-sqlite v1.21.2 // indirect
 	github.com/google/uuid v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -32,6 +34,7 @@ github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,59 +10,123 @@ import (
 
 // Config agrupa par?metros de conex?o e exporta??o.
 type Config struct {
-	Driver  string
-	DSN     string
-	Table   string
-	Column  string
-	Record  string
-	OutFile string
-	NewIDs  bool
+	Driver       string
+	OutputDriver string
+	DSN          string
+	Table        string
+	Column       string
+	Record       string
+	OutFile      string
+	NewIDs       bool
+	Log          bool
+
+	driverSet       bool
+	outputDriverSet bool
+	dsnSet          bool
+	tableSet        bool
+	columnSet       bool
+	recordSet       bool
+	outFileSet      bool
+	newIDsSet       bool
+	logSet          bool
 }
 
 // Default l? valores do ambiente e define padr?es.
 func Default() Config {
+	driver, driverSet := lookupEnv("TRACESQL_DRIVER")
+	outputDriver, outputDriverSet := lookupEnv("TRACESQL_OUTPUT_DRIVER")
+	dsn, dsnSet := lookupEnv("TRACESQL_DSN")
+	outFile, outFileSet := lookupEnv("TRACESQL_OUT")
+	newIDsRaw, newIDsSet := lookupEnv("TRACESQL_NEW_IDS")
+	logRaw, logSet := lookupEnv("TRACESQL_LOG")
+
 	return Config{
-		Driver:  getEnv("TRACESQL_DRIVER", ""),
-		DSN:     getEnv("TRACESQL_DSN", ""),
-		Column:  "id",
-		OutFile: getEnv("TRACESQL_OUT", ""),
-		NewIDs:  strings.EqualFold(getEnv("TRACESQL_NEW_IDS", "false"), "true"),
+		Driver:          driver,
+		OutputDriver:    outputDriver,
+		DSN:             dsn,
+		Column:          "id",
+		OutFile:         outFile,
+		NewIDs:          strings.EqualFold(newIDsRaw, "true"),
+		Log:             parseBool(logRaw),
+		driverSet:       driverSet,
+		outputDriverSet: outputDriverSet,
+		dsnSet:          dsnSet,
+		outFileSet:      outFileSet,
+		newIDsSet:       newIDsSet,
+		logSet:          logSet,
 	}
 }
 
 // AttachFlags registra as flags do CLI.
 func AttachFlags(cmd *cobra.Command, cfg Config) {
 	cmd.PersistentFlags().String("driver", cfg.Driver, "Driver do banco (postgres, mysql, sqlite)")
+	cmd.PersistentFlags().String("output-driver", cfg.OutputDriver, "Dialeto do SQL gerado (padrao: mesmo driver da origem)")
 	cmd.PersistentFlags().String("dsn", cfg.DSN, "DSN de conex?o do banco")
 	cmd.PersistentFlags().String("table", cfg.Table, "Tabela de origem")
 	cmd.PersistentFlags().String("column", cfg.Column, "Coluna de refer?ncia (padr?o id)")
 	cmd.PersistentFlags().String("record", cfg.Record, "Valor do registro a exportar")
 	cmd.PersistentFlags().String("out", cfg.OutFile, "Caminho do arquivo .sql a gerar")
 	cmd.PersistentFlags().Bool("new-ids", cfg.NewIDs, "Gerar novos IDs (omite a coluna de refer?ncia no insert)")
+	cmd.PersistentFlags().Bool("log", cfg.Log, "Exibe logs de execução no stderr")
 }
 
 // BindFlags aplica os valores das flags na config.
 func BindFlags(cmd *cobra.Command, cfg *Config) error {
-	if v, err := cmd.Flags().GetString("driver"); err == nil && v != "" {
+	flags := cmd.Flags()
+
+	if flags.Changed("driver") {
+		cfg.driverSet = true
+	}
+	if v, err := flags.GetString("driver"); err == nil && v != "" {
 		cfg.Driver = v
 	}
-	if v, err := cmd.Flags().GetString("dsn"); err == nil && v != "" {
+	if flags.Changed("output-driver") {
+		cfg.outputDriverSet = true
+	}
+	if v, err := flags.GetString("output-driver"); err == nil && v != "" {
+		cfg.OutputDriver = v
+	}
+	if flags.Changed("dsn") {
+		cfg.dsnSet = true
+	}
+	if v, err := flags.GetString("dsn"); err == nil && v != "" {
 		cfg.DSN = v
 	}
-	if v, err := cmd.Flags().GetString("table"); err == nil && v != "" {
+	if flags.Changed("table") {
+		cfg.tableSet = true
+	}
+	if v, err := flags.GetString("table"); err == nil && v != "" {
 		cfg.Table = v
 	}
-	if v, err := cmd.Flags().GetString("column"); err == nil && v != "" {
+	if flags.Changed("column") {
+		cfg.columnSet = true
+	}
+	if v, err := flags.GetString("column"); err == nil && v != "" {
 		cfg.Column = v
 	}
-	if v, err := cmd.Flags().GetString("record"); err == nil && v != "" {
+	if flags.Changed("record") {
+		cfg.recordSet = true
+	}
+	if v, err := flags.GetString("record"); err == nil && v != "" {
 		cfg.Record = v
 	}
-	if v, err := cmd.Flags().GetString("out"); err == nil && v != "" {
+	if flags.Changed("out") {
+		cfg.outFileSet = true
+	}
+	if v, err := flags.GetString("out"); err == nil && v != "" {
 		cfg.OutFile = v
 	}
-	if v, err := cmd.Flags().GetBool("new-ids"); err == nil {
+	if flags.Changed("new-ids") {
+		cfg.newIDsSet = true
+	}
+	if v, err := flags.GetBool("new-ids"); err == nil {
 		cfg.NewIDs = v
+	}
+	if flags.Changed("log") {
+		cfg.logSet = true
+	}
+	if v, err := flags.GetBool("log"); err == nil {
+		cfg.Log = v
 	}
 	return nil
 }
@@ -99,8 +163,12 @@ func (c Config) OutPath() string {
 	return "export.sql"
 }
 
+func lookupEnv(key string) (string, bool) {
+	return os.LookupEnv(key)
+}
+
 func getEnv(key, fallback string) string {
-	if v, ok := os.LookupEnv(key); ok {
+	if v, ok := lookupEnv(key); ok {
 		return v
 	}
 	return fallback
@@ -110,31 +178,43 @@ func getEnv(key, fallback string) string {
 func (c *Config) WithPrompts(values map[string]string) {
 	if c.Driver == "" {
 		c.Driver = values["driver"]
+		c.driverSet = c.Driver != ""
 	}
 	if c.DSN == "" {
 		c.DSN = values["dsn"]
+		c.dsnSet = c.DSN != ""
 	}
 	if c.Table == "" {
 		c.Table = values["table"]
+		c.tableSet = c.Table != ""
 	}
 	if c.Column == "" {
 		c.Column = "id"
 	}
 	if c.Record == "" {
 		c.Record = values["record"]
+		c.recordSet = c.Record != ""
 	}
 }
 
 // Normalize reduz abrevia??es dos drivers.
 func (c *Config) Normalize() {
-	d := strings.ToLower(c.Driver)
-	switch d {
+	switch strings.ToLower(c.Driver) {
 	case "postgres", "postgresql", "pg":
 		c.Driver = "postgres"
 	case "mysql":
 		c.Driver = "mysql"
 	case "sqlite", "sqlite3":
 		c.Driver = "sqlite"
+	}
+
+	switch strings.ToLower(c.OutputDriver) {
+	case "postgres", "postgresql", "pg":
+		c.OutputDriver = "postgres"
+	case "mysql":
+		c.OutputDriver = "mysql"
+	case "sqlite", "sqlite3":
+		c.OutputDriver = "sqlite"
 	}
 }
 
@@ -147,5 +227,41 @@ func (c *Config) MergeEnv(env map[string]string) {
 func (c *Config) EnsureDefaults() {
 	if c.Column == "" {
 		c.Column = "id"
+	}
+	if c.OutputDriver == "" && c.Driver != "" {
+		c.OutputDriver = c.Driver
+	}
+}
+
+func (c Config) DriverProvided() bool {
+	return c.driverSet
+}
+
+func (c Config) DSNProvided() bool {
+	return c.dsnSet
+}
+
+func (c Config) TableProvided() bool {
+	return c.tableSet
+}
+
+func (c Config) ColumnProvided() bool {
+	return c.columnSet
+}
+
+func (c Config) RecordProvided() bool {
+	return c.recordSet
+}
+
+func (c Config) NewIDsProvided() bool {
+	return c.newIDsSet
+}
+
+func parseBool(raw string) bool {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "1", "t", "true", "y", "yes", "s", "sim":
+		return true
+	default:
+		return false
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestDefaultFromEnv(t *testing.T) {
 	t.Setenv("TRACESQL_DRIVER", "postgres")
+	t.Setenv("TRACESQL_OUTPUT_DRIVER", "mysql")
 	t.Setenv("TRACESQL_DSN", "postgres://user:pass@localhost/db")
 	t.Setenv("TRACESQL_NEW_IDS", "true")
 
@@ -16,6 +17,9 @@ func TestDefaultFromEnv(t *testing.T) {
 
 	if cfg.Driver != "postgres" || cfg.DSN == "" {
 		t.Fatalf("env não aplicado corretamente: %+v", cfg)
+	}
+	if cfg.OutputDriver != "mysql" {
+		t.Fatalf("output driver não aplicado corretamente: %+v", cfg)
 	}
 	if cfg.Table != "" || cfg.Record != "" {
 		t.Fatalf("table/record não deveriam vir do env: %+v", cfg)
@@ -64,10 +68,13 @@ func TestNormalize(t *testing.T) {
 }
 
 func TestEnsureDefaults(t *testing.T) {
-	cfg := config.Config{}
+	cfg := config.Config{Driver: "sqlite"}
 	cfg.EnsureDefaults()
 	if cfg.Column != "id" {
 		t.Fatalf("coluna padr?o deveria ser id, obtido %s", cfg.Column)
+	}
+	if cfg.OutputDriver != "sqlite" {
+		t.Fatalf("output driver padrão deveria seguir o driver, obtido %s", cfg.OutputDriver)
 	}
 
 	os.Unsetenv("TRACESQL_COLUMN")

--- a/internal/export/exporter.go
+++ b/internal/export/exporter.go
@@ -5,71 +5,729 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
+	"regexp"
+	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/Felipe-Cavalca/TraceSQL/internal/config"
+	"github.com/Felipe-Cavalca/TraceSQL/internal/metadata"
 )
 
-// Run executa a exporta??o de um registro e retorna o SQL gerado.
+var (
+	decimalTypePattern = regexp.MustCompile(`(?:numeric|decimal)\(([^)]+)\)`)
+	varcharTypePattern = regexp.MustCompile(`(?:character varying|varchar)\((\d+)\)`)
+	charTypePattern    = regexp.MustCompile(`(?:character|char)\((\d+)\)`)
+)
+
+type newIDMapping struct {
+	Table    string
+	MapTable string
+	PK       metadata.Column
+}
+
+type traceLogger func(string, ...interface{})
+
+// Run executa a exportação do registro inicial e das suas relações.
 func Run(ctx context.Context, db *sql.DB, cfg config.Config) (string, error) {
 	cfg.Normalize()
 	cfg.EnsureDefaults()
+	logf := newTraceLogger(cfg.Log)
+	logf("iniciando export: source=%s target=%s table=%s column=%s record=%s new_ids=%t", cfg.Driver, cfg.OutputDriver, cfg.Table, cfg.Column, cfg.Record, cfg.NewIDs)
 
-	placeholder := placeholderFor(cfg.Driver)
-	query := fmt.Sprintf("SELECT * FROM %s WHERE %s = %s LIMIT 1", quoteIdent(cfg.Driver, cfg.Table), quoteIdent(cfg.Driver, cfg.Column), placeholder)
-
-	rows, err := db.QueryContext(ctx, query, cfg.Record)
+	baseRows, err := queryRowsByValue(ctx, db, cfg.Driver, cfg.Table, cfg.Column, cfg.Record, logf)
 	if err != nil {
 		return "", fmt.Errorf("consulta de origem: %w", err)
+	}
+	if len(baseRows) == 0 {
+		return "", errors.New("nenhum registro encontrado com o valor informado")
+	}
+	logf("linhas base encontradas: %d", len(baseRows))
+
+	catalog, err := metadata.Discover(ctx, db, cfg.Driver)
+	if err != nil {
+		return "", fmt.Errorf("descobrindo metadata: %w", err)
+	}
+	logf("metadata descoberta: %d tabelas e %d foreign keys", len(catalog.TableNames()), len(catalog.ForeignKeys))
+
+	if tableMeta, ok := catalog.Table(cfg.Table); ok {
+		cfg.Table = tableMeta.Name
+	}
+	for i := range baseRows {
+		baseRows[i].table = cfg.Table
+	}
+
+	rowsByTable, err := collectRows(ctx, db, cfg, catalog, baseRows, logf)
+	if err != nil {
+		return "", err
+	}
+	if len(rowsByTable) == 0 {
+		return "", errors.New("nenhuma linha encontrada para exportação")
+	}
+	logf("grafo coletado: %s", summarizeRowsByTable(rowsByTable))
+
+	tableOrder := orderedTables(catalog, rowsByTable)
+	exportedTables := make(map[string]struct{}, len(tableOrder))
+	for _, tableName := range tableOrder {
+		exportedTables[strings.ToLower(tableName)] = struct{}{}
+	}
+
+	mappings := buildNewIDMappings(catalog, tableOrder, cfg.NewIDs)
+
+	var builder strings.Builder
+	for _, tableName := range tableOrder {
+		tableMeta, ok := catalog.Table(tableName)
+		if !ok {
+			return "", fmt.Errorf("metadata ausente para a tabela %s", tableName)
+		}
+		logf("gerando schema da tabela %s", tableName)
+		builder.WriteString(buildCreateTable(cfg.OutputDriver, tableMeta, foreignKeysForTable(catalog, exportedTables, tableName)))
+	}
+
+	if cfg.NewIDs {
+		for _, tableName := range tableOrder {
+			mapping, ok := mappings[strings.ToLower(tableName)]
+			if !ok {
+				continue
+			}
+			logf("criando tabela temporária de mapeamento para %s", tableName)
+			builder.WriteString(buildMappingTableSetup(cfg.OutputDriver, mapping))
+		}
+	}
+
+	for _, tableName := range tableOrder {
+		rows := orderRowsForInsert(
+			catalog,
+			tableName,
+			rowsByTable[tableName],
+			tableForeignKeys(catalog, tableName),
+			mappings,
+		)
+
+		tableMeta, _ := catalog.Table(tableName)
+		logf("gerando inserts da tabela %s (%d linhas)", tableName, len(rows))
+		for _, row := range rows {
+			stmt, err := buildInsert(cfg, row, tableMeta, tableForeignKeys(catalog, tableName), mappings)
+			if err != nil {
+				return "", err
+			}
+			builder.WriteString(stmt)
+		}
+	}
+
+	if builder.Len() == 0 {
+		return "", errors.New("nenhum SQL foi gerado")
+	}
+
+	return builder.String(), nil
+}
+
+type scannedRow struct {
+	table string
+	cols  []string
+	types []*sql.ColumnType
+	dests []sql.NullString
+	index map[string]int
+}
+
+func collectRows(ctx context.Context, db *sql.DB, cfg config.Config, catalog metadata.Catalog, baseRows []scannedRow, logf traceLogger) (map[string][]scannedRow, error) {
+	queue := append([]scannedRow(nil), baseRows...)
+	rowsByTable := map[string][]scannedRow{}
+	seen := map[string]struct{}{}
+
+	for len(queue) > 0 {
+		row := queue[0]
+		queue = queue[1:]
+
+		tableMeta, ok := catalog.Table(row.table)
+		if ok {
+			row.table = tableMeta.Name
+		}
+
+		identity := rowIdentity(tableMeta, row)
+		if _, exists := seen[identity]; exists {
+			continue
+		}
+		seen[identity] = struct{}{}
+		rowsByTable[row.table] = append(rowsByTable[row.table], row)
+
+		relatedRows, err := relatedRowsForRow(ctx, db, cfg.Driver, catalog, row, logf)
+		if err != nil {
+			return nil, err
+		}
+		queue = append(queue, relatedRows...)
+	}
+
+	return rowsByTable, nil
+}
+
+func relatedRowsForRow(ctx context.Context, db *sql.DB, sourceDriver string, catalog metadata.Catalog, row scannedRow, logf traceLogger) ([]scannedRow, error) {
+	var related []scannedRow
+
+	for _, fk := range catalog.ForeignKeys {
+		switch {
+		case strings.EqualFold(fk.Table, row.table):
+			value, ok := valueForColumn(row, fk.Column)
+			if !ok || !value.Valid {
+				continue
+			}
+
+			parentRows, err := queryRowsByValue(ctx, db, sourceDriver, fk.RefTable, fk.RefColumn, value.String, logf)
+			if err != nil {
+				return nil, fmt.Errorf("consultando pai %s.%s -> %s.%s: %w", fk.Table, fk.Column, fk.RefTable, fk.RefColumn, err)
+			}
+			related = append(related, parentRows...)
+
+		case strings.EqualFold(fk.RefTable, row.table):
+			value, ok := valueForColumn(row, fk.RefColumn)
+			if !ok || !value.Valid {
+				continue
+			}
+
+			childRows, err := queryRowsByValue(ctx, db, sourceDriver, fk.Table, fk.Column, value.String, logf)
+			if err != nil {
+				return nil, fmt.Errorf("consultando filho %s.%s -> %s.%s: %w", fk.Table, fk.Column, fk.RefTable, fk.RefColumn, err)
+			}
+			related = append(related, childRows...)
+		}
+	}
+
+	return related, nil
+}
+
+func queryRowsByValue(ctx context.Context, db *sql.DB, driver, table, column, value string, logf traceLogger) ([]scannedRow, error) {
+	logf("consultando %s onde %s = %s", table, column, value)
+	query := fmt.Sprintf(
+		"SELECT * FROM %s WHERE %s = %s",
+		quoteIdent(driver, table),
+		quoteIdent(driver, column),
+		placeholderFor(driver),
+	)
+
+	rows, err := scanQuery(ctx, db, query, value)
+	if err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		rows[i].table = table
+	}
+	logf("consulta retornou %d linhas para %s", len(rows), table)
+	return rows, nil
+}
+
+func scanQuery(ctx context.Context, db *sql.DB, query string, args ...interface{}) ([]scannedRow, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
 	}
 	defer rows.Close()
 
 	cols, err := rows.Columns()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-
 	types, err := rows.ColumnTypes()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	if !rows.Next() {
-		return "", errors.New("nenhum registro encontrado com o valor informado")
+	var out []scannedRow
+	for rows.Next() {
+		scanned := make([]interface{}, len(cols))
+		dests := make([]sql.NullString, len(cols))
+		index := make(map[string]int, len(cols))
+		for i := range scanned {
+			scanned[i] = &dests[i]
+			index[strings.ToLower(cols[i])] = i
+		}
+		if err := rows.Scan(scanned...); err != nil {
+			return nil, err
+		}
+		out = append(out, scannedRow{
+			cols:  cols,
+			types: types,
+			dests: dests,
+			index: index,
+		})
 	}
 
-	scanned := make([]interface{}, len(cols))
-	dests := make([]sql.NullString, len(cols))
-	for i := range scanned {
-		scanned[i] = &dests[i]
-	}
+	return out, rows.Err()
+}
 
-	if err := rows.Scan(scanned...); err != nil {
-		return "", err
-	}
+func buildCreateTable(outputDriver string, table metadata.Table, foreignKeys []metadata.ForeignKey) string {
+	pkColumns := table.PrimaryKeyColumns()
+	inlineAutoPrimaryKey := len(pkColumns) == 1
 
-	insertCols := []string{}
-	insertVals := []string{}
+	definitions := make([]string, 0, len(table.Columns)+len(foreignKeys)+1)
+	for _, column := range table.Columns {
+		columnType := mapColumnType(outputDriver, column.Type)
+		identifier := quoteIdent(outputDriver, column.Name)
 
-	for i, col := range cols {
-		if cfg.NewIDs && strings.EqualFold(col, cfg.Column) {
+		if normalizeDialect(outputDriver) == "sqlite" && inlineAutoPrimaryKey && column.PrimaryKey && column.AutoIncrement {
+			definitions = append(definitions, fmt.Sprintf("%s INTEGER PRIMARY KEY AUTOINCREMENT", identifier))
 			continue
 		}
 
-		insertCols = append(insertCols, quoteIdent(cfg.Driver, col))
-		insertVals = append(insertVals, formatValue(dests[i], types[i]))
+		var parts []string
+		parts = append(parts, identifier, columnType)
+		if column.AutoIncrement && isIntegerType(columnType) {
+			switch normalizeDialect(outputDriver) {
+			case "postgres":
+				parts = append(parts, "GENERATED BY DEFAULT AS IDENTITY")
+			case "mysql":
+				parts = append(parts, "AUTO_INCREMENT")
+			}
+		}
+		if column.PrimaryKey || !column.Nullable {
+			parts = append(parts, "NOT NULL")
+		}
+
+		definitions = append(definitions, strings.Join(parts, " "))
+	}
+
+	if len(pkColumns) > 0 && !(normalizeDialect(outputDriver) == "sqlite" && inlineAutoPrimaryKey && hasSingleAutoPrimaryKey(table)) {
+		definitions = append(definitions, fmt.Sprintf("PRIMARY KEY (%s)", joinQuoted(outputDriver, pkColumns)))
+	}
+
+	for _, fk := range foreignKeys {
+		definitions = append(definitions, fmt.Sprintf(
+			"FOREIGN KEY (%s) REFERENCES %s (%s)",
+			quoteIdent(outputDriver, fk.Column),
+			quoteIdent(outputDriver, fk.RefTable),
+			quoteIdent(outputDriver, fk.RefColumn),
+		))
+	}
+
+	return fmt.Sprintf("CREATE TABLE IF NOT EXISTS %s (\n  %s\n);\n", quoteIdent(outputDriver, table.Name), strings.Join(definitions, ",\n  "))
+}
+
+func hasSingleAutoPrimaryKey(table metadata.Table) bool {
+	_, ok := singleAutoIncrementPrimaryKey(table)
+	return ok
+}
+
+func buildInsert(cfg config.Config, row scannedRow, tableMeta metadata.Table, tableForeignKeys []metadata.ForeignKey, mappings map[string]newIDMapping) (string, error) {
+	table := row.table
+	if table == "" {
+		table = cfg.Table
+	}
+
+	mapping, mappedTable := mappings[strings.ToLower(table)]
+	insertCols := []string{}
+	insertVals := []string{}
+
+	for i, col := range row.cols {
+		if cfg.NewIDs && mappedTable && strings.EqualFold(col, mapping.PK.Name) {
+			continue
+		}
+
+		insertCols = append(insertCols, quoteIdent(cfg.OutputDriver, col))
+		insertVals = append(insertVals, buildValueExpression(cfg.OutputDriver, row, i, tableForeignKeys, mappings))
 	}
 
 	if len(insertCols) == 0 {
 		return "", errors.New("nenhuma coluna para exportar")
 	}
 
-	stmt := fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s);\n", quoteIdent(cfg.Driver, cfg.Table), strings.Join(insertCols, ", "), strings.Join(insertVals, ", "))
-	return stmt, nil
+	if cfg.NewIDs && mappedTable {
+		oldPKValue, ok := valueForColumn(row, mapping.PK.Name)
+		if !ok || !oldPKValue.Valid {
+			return "", fmt.Errorf("não foi possível localizar o valor antigo da PK %s.%s", table, mapping.PK.Name)
+		}
+		pkType := row.types[row.index[strings.ToLower(mapping.PK.Name)]]
+		return buildInsertWithMapping(cfg.OutputDriver, table, insertCols, insertVals, mapping, formatValue(oldPKValue, pkType)), nil
+	}
+
+	return fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES (%s);\n",
+		quoteIdent(cfg.OutputDriver, table),
+		strings.Join(insertCols, ", "),
+		strings.Join(insertVals, ", "),
+	), nil
+}
+
+func buildValueExpression(outputDriver string, row scannedRow, columnIndex int, tableForeignKeys []metadata.ForeignKey, mappings map[string]newIDMapping) string {
+	columnName := row.cols[columnIndex]
+	for _, fk := range tableForeignKeys {
+		if !strings.EqualFold(fk.Column, columnName) {
+			continue
+		}
+
+		mapping, ok := mappings[strings.ToLower(fk.RefTable)]
+		if !ok || !strings.EqualFold(fk.RefColumn, mapping.PK.Name) {
+			break
+		}
+
+		return buildMappedReferenceExpression(outputDriver, mapping, row.dests[columnIndex], row.types[columnIndex])
+	}
+
+	return formatValue(row.dests[columnIndex], row.types[columnIndex])
+}
+
+func buildInsertWithMapping(outputDriver, table string, insertCols, insertVals []string, mapping newIDMapping, oldPKExpr string) string {
+	insertTarget := quoteIdent(outputDriver, table)
+	insertColumns := strings.Join(insertCols, ", ")
+	insertValues := strings.Join(insertVals, ", ")
+	mapTarget := quoteIdent(outputDriver, mapping.MapTable)
+	oldIDColumn := quoteIdent(outputDriver, "old_id")
+	newIDColumn := quoteIdent(outputDriver, "new_id")
+	pkColumn := quoteIdent(outputDriver, mapping.PK.Name)
+
+	switch normalizeDialect(outputDriver) {
+	case "postgres":
+		return fmt.Sprintf(
+			"WITH inserted AS (\n  INSERT INTO %s (%s) VALUES (%s) RETURNING %s\n)\nINSERT INTO %s (%s, %s)\nSELECT %s, %s FROM inserted;\n",
+			insertTarget,
+			insertColumns,
+			insertValues,
+			pkColumn,
+			mapTarget,
+			oldIDColumn,
+			newIDColumn,
+			oldPKExpr,
+			pkColumn,
+		)
+	case "mysql":
+		return fmt.Sprintf(
+			"INSERT INTO %s (%s) VALUES (%s);\nINSERT INTO %s (%s, %s) VALUES (%s, LAST_INSERT_ID());\n",
+			insertTarget,
+			insertColumns,
+			insertValues,
+			mapTarget,
+			oldIDColumn,
+			newIDColumn,
+			oldPKExpr,
+		)
+	default:
+		return fmt.Sprintf(
+			"INSERT INTO %s (%s) VALUES (%s);\nINSERT INTO %s (%s, %s) VALUES (%s, last_insert_rowid());\n",
+			insertTarget,
+			insertColumns,
+			insertValues,
+			mapTarget,
+			oldIDColumn,
+			newIDColumn,
+			oldPKExpr,
+		)
+	}
+}
+
+func buildMappedReferenceExpression(outputDriver string, mapping newIDMapping, oldValue sql.NullString, colType *sql.ColumnType) string {
+	if !oldValue.Valid {
+		return "NULL"
+	}
+
+	return fmt.Sprintf(
+		"(SELECT %s FROM %s WHERE %s = %s)",
+		quoteIdent(outputDriver, "new_id"),
+		quoteIdent(outputDriver, mapping.MapTable),
+		quoteIdent(outputDriver, "old_id"),
+		formatValue(oldValue, colType),
+	)
+}
+
+func buildNewIDMappings(catalog metadata.Catalog, tableOrder []string, enabled bool) map[string]newIDMapping {
+	if !enabled {
+		return nil
+	}
+
+	mappings := map[string]newIDMapping{}
+	for _, tableName := range tableOrder {
+		tableMeta, ok := catalog.Table(tableName)
+		if !ok {
+			continue
+		}
+
+		pk, ok := singleAutoIncrementPrimaryKey(tableMeta)
+		if !ok {
+			continue
+		}
+
+		mappings[strings.ToLower(tableName)] = newIDMapping{
+			Table:    tableMeta.Name,
+			MapTable: mappingTableName(tableMeta.Name),
+			PK:       pk,
+		}
+	}
+	return mappings
+}
+
+func singleAutoIncrementPrimaryKey(table metadata.Table) (metadata.Column, bool) {
+	pkColumns := table.PrimaryKeyColumns()
+	if len(pkColumns) != 1 {
+		return metadata.Column{}, false
+	}
+
+	for _, column := range table.Columns {
+		if column.PrimaryKey && column.AutoIncrement {
+			return column, true
+		}
+	}
+
+	return metadata.Column{}, false
+}
+
+func buildMappingTableSetup(outputDriver string, mapping newIDMapping) string {
+	tableName := quoteIdent(outputDriver, mapping.MapTable)
+	idType := "BIGINT"
+	if normalizeDialect(outputDriver) == "sqlite" {
+		idType = "INTEGER"
+	}
+
+	switch normalizeDialect(outputDriver) {
+	case "mysql":
+		return fmt.Sprintf(
+			"DROP TEMPORARY TABLE IF EXISTS %s;\nCREATE TEMPORARY TABLE %s (%s %s NOT NULL PRIMARY KEY, %s %s NOT NULL);\n",
+			tableName,
+			tableName,
+			quoteIdent(outputDriver, "old_id"),
+			idType,
+			quoteIdent(outputDriver, "new_id"),
+			idType,
+		)
+	default:
+		return fmt.Sprintf(
+			"DROP TABLE IF EXISTS %s;\nCREATE TEMP TABLE %s (%s %s NOT NULL PRIMARY KEY, %s %s NOT NULL);\n",
+			tableName,
+			tableName,
+			quoteIdent(outputDriver, "old_id"),
+			idType,
+			quoteIdent(outputDriver, "new_id"),
+			idType,
+		)
+	}
+}
+
+func mappingTableName(table string) string {
+	var builder strings.Builder
+	builder.WriteString("__tracesql_map_")
+	for _, r := range strings.ToLower(table) {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			builder.WriteRune(r)
+			continue
+		}
+		builder.WriteRune('_')
+	}
+	return builder.String()
+}
+
+func foreignKeysForTable(catalog metadata.Catalog, exportedTables map[string]struct{}, table string) []metadata.ForeignKey {
+	var filtered []metadata.ForeignKey
+	for _, fk := range catalog.ForeignKeys {
+		if !strings.EqualFold(fk.Table, table) {
+			continue
+		}
+		if _, ok := exportedTables[strings.ToLower(fk.RefTable)]; !ok {
+			continue
+		}
+		filtered = append(filtered, fk)
+	}
+	return filtered
+}
+
+func tableForeignKeys(catalog metadata.Catalog, table string) []metadata.ForeignKey {
+	var filtered []metadata.ForeignKey
+	for _, fk := range catalog.ForeignKeys {
+		if strings.EqualFold(fk.Table, table) {
+			filtered = append(filtered, fk)
+		}
+	}
+	return filtered
+}
+
+func orderRowsForInsert(catalog metadata.Catalog, tableName string, rows []scannedRow, tableForeignKeys []metadata.ForeignKey, mappings map[string]newIDMapping) []scannedRow {
+	ordered := append([]scannedRow(nil), rows...)
+	tableMeta, _ := catalog.Table(tableName)
+	sort.Slice(ordered, func(i, j int) bool {
+		return rowIdentity(tableMeta, ordered[i]) < rowIdentity(tableMeta, ordered[j])
+	})
+
+	mapping, ok := mappings[strings.ToLower(tableName)]
+	if !ok {
+		return ordered
+	}
+
+	var selfReferences []metadata.ForeignKey
+	for _, fk := range tableForeignKeys {
+		if strings.EqualFold(fk.RefTable, tableName) && strings.EqualFold(fk.RefColumn, mapping.PK.Name) {
+			selfReferences = append(selfReferences, fk)
+		}
+	}
+	if len(selfReferences) == 0 {
+		return ordered
+	}
+
+	pending := append([]scannedRow(nil), ordered...)
+	var result []scannedRow
+
+	for len(pending) > 0 {
+		pendingIDs := map[string]struct{}{}
+		for _, row := range pending {
+			value, ok := valueForColumn(row, mapping.PK.Name)
+			if ok && value.Valid {
+				pendingIDs[value.String] = struct{}{}
+			}
+		}
+
+		progress := false
+		nextPending := make([]scannedRow, 0, len(pending))
+		for _, row := range pending {
+			ready := true
+			for _, fk := range selfReferences {
+				value, ok := valueForColumn(row, fk.Column)
+				if !ok || !value.Valid {
+					continue
+				}
+				if _, blocked := pendingIDs[value.String]; blocked {
+					currentID, hasCurrentID := valueForColumn(row, mapping.PK.Name)
+					if !hasCurrentID || !currentID.Valid || currentID.String != value.String {
+						ready = false
+						break
+					}
+				}
+			}
+
+			if ready {
+				result = append(result, row)
+				progress = true
+				continue
+			}
+			nextPending = append(nextPending, row)
+		}
+
+		if !progress {
+			return ordered
+		}
+		pending = nextPending
+	}
+
+	return result
+}
+
+func orderedTables(catalog metadata.Catalog, rowsByTable map[string][]scannedRow) []string {
+	exportedTables := make(map[string]string, len(rowsByTable))
+	for tableName := range rowsByTable {
+		exportedTables[strings.ToLower(tableName)] = tableName
+	}
+
+	adjacency := map[string][]string{}
+	indegree := map[string]int{}
+	for _, tableName := range catalog.TableNames() {
+		if _, ok := exportedTables[strings.ToLower(tableName)]; ok {
+			indegree[tableName] = 0
+		}
+	}
+
+	seenEdges := map[string]struct{}{}
+	for _, fk := range catalog.ForeignKeys {
+		parentName, parentOK := exportedTables[strings.ToLower(fk.RefTable)]
+		childName, childOK := exportedTables[strings.ToLower(fk.Table)]
+		if !parentOK || !childOK {
+			continue
+		}
+
+		edgeKey := strings.ToLower(parentName) + "->" + strings.ToLower(childName)
+		if _, exists := seenEdges[edgeKey]; exists {
+			continue
+		}
+		seenEdges[edgeKey] = struct{}{}
+		adjacency[parentName] = append(adjacency[parentName], childName)
+		indegree[childName]++
+	}
+
+	var ready []string
+	for tableName := range indegree {
+		if indegree[tableName] == 0 {
+			ready = append(ready, tableName)
+		}
+	}
+	sort.Strings(ready)
+
+	var ordered []string
+	for len(ready) > 0 {
+		current := ready[0]
+		ready = ready[1:]
+		ordered = append(ordered, current)
+
+		children := adjacency[current]
+		sort.Strings(children)
+		for _, child := range children {
+			indegree[child]--
+			if indegree[child] == 0 {
+				ready = append(ready, child)
+				sort.Strings(ready)
+			}
+		}
+	}
+
+	if len(ordered) == len(exportedTables) {
+		return ordered
+	}
+
+	var remaining []string
+	for _, tableName := range catalog.TableNames() {
+		if _, ok := exportedTables[strings.ToLower(tableName)]; !ok {
+			continue
+		}
+		if !containsString(ordered, tableName) {
+			remaining = append(remaining, tableName)
+		}
+	}
+	sort.Strings(remaining)
+	return append(ordered, remaining...)
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func rowIdentity(table metadata.Table, row scannedRow) string {
+	keyParts := []string{strings.ToLower(row.table)}
+	pkColumns := table.PrimaryKeyColumns()
+	if len(pkColumns) > 0 {
+		for _, column := range pkColumns {
+			value, ok := valueForColumn(row, column)
+			if !ok {
+				pkColumns = nil
+				break
+			}
+			keyParts = append(keyParts, strings.ToLower(column), nullableValueString(value))
+		}
+		if len(pkColumns) > 0 {
+			return strings.Join(keyParts, "|")
+		}
+	}
+
+	keyParts = keyParts[:1]
+	for i, column := range row.cols {
+		keyParts = append(keyParts, strings.ToLower(column), nullableValueString(row.dests[i]))
+	}
+	return strings.Join(keyParts, "|")
+}
+
+func valueForColumn(row scannedRow, column string) (sql.NullString, bool) {
+	position, ok := row.index[strings.ToLower(column)]
+	if !ok {
+		return sql.NullString{}, false
+	}
+	return row.dests[position], true
+}
+
+func nullableValueString(value sql.NullString) string {
+	if !value.Valid {
+		return "NULL"
+	}
+	return value.String
 }
 
 func placeholderFor(driver string) string {
-	if strings.HasPrefix(strings.ToLower(driver), "postgres") || strings.ToLower(driver) == "pg" {
+	if normalizeDialect(driver) == "postgres" {
 		return "$1"
 	}
 	return "?"
@@ -79,21 +737,176 @@ func quoteIdent(driver, ident string) string {
 	if ident == "" {
 		return ident
 	}
+
 	clean := strings.ReplaceAll(ident, "`", "")
-	clean = strings.ReplaceAll(clean, "\"", "")
-	if strings.HasPrefix(strings.ToLower(driver), "postgres") || strings.ToLower(driver) == "pg" {
-		return fmt.Sprintf("\"%s\"", clean)
+	clean = strings.ReplaceAll(clean, `"`, "")
+	if normalizeDialect(driver) == "postgres" {
+		return fmt.Sprintf(`"%s"`, clean)
 	}
 	return fmt.Sprintf("`%s`", clean)
+}
+
+func joinQuoted(driver string, identifiers []string) string {
+	quoted := make([]string, 0, len(identifiers))
+	for _, identifier := range identifiers {
+		quoted = append(quoted, quoteIdent(driver, identifier))
+	}
+	return strings.Join(quoted, ", ")
+}
+
+func normalizeDialect(driver string) string {
+	switch strings.ToLower(driver) {
+	case "postgres", "postgresql", "pg":
+		return "postgres"
+	case "mysql":
+		return "mysql"
+	case "sqlite", "sqlite3":
+		return "sqlite"
+	default:
+		return strings.ToLower(driver)
+	}
+}
+
+func mapColumnType(targetDriver, rawType string) string {
+	target := normalizeDialect(targetDriver)
+	lower := strings.ToLower(strings.TrimSpace(rawType))
+
+	switch {
+	case lower == "":
+		return "TEXT"
+	case strings.Contains(lower, "bigserial"), strings.Contains(lower, "bigint"), strings.Contains(lower, "int8"):
+		return mapIntegerType(target, "big")
+	case strings.Contains(lower, "smallserial"), strings.Contains(lower, "smallint"), strings.Contains(lower, "int2"):
+		return mapIntegerType(target, "small")
+	case strings.Contains(lower, "serial"), strings.Contains(lower, "integer"), strings.Contains(lower, "int"), strings.Contains(lower, "mediumint"):
+		if strings.Contains(lower, "tinyint(1)") {
+			return "BOOLEAN"
+		}
+		return mapIntegerType(target, "default")
+	case strings.Contains(lower, "bool"):
+		return "BOOLEAN"
+	case decimalTypePattern.MatchString(lower):
+		match := decimalTypePattern.FindStringSubmatch(lower)
+		return mapDecimalType(target, match[1])
+	case strings.Contains(lower, "numeric"), strings.Contains(lower, "decimal"):
+		return mapDecimalType(target, "")
+	case strings.Contains(lower, "double"), strings.Contains(lower, "float8"):
+		return mapFloatType(target, true)
+	case strings.Contains(lower, "real"), strings.Contains(lower, "float4"):
+		return mapFloatType(target, false)
+	case strings.Contains(lower, "float"):
+		return mapFloatType(target, true)
+	case varcharTypePattern.MatchString(lower):
+		match := varcharTypePattern.FindStringSubmatch(lower)
+		return fmt.Sprintf("VARCHAR(%s)", match[1])
+	case charTypePattern.MatchString(lower):
+		match := charTypePattern.FindStringSubmatch(lower)
+		return fmt.Sprintf("CHAR(%s)", match[1])
+	case strings.Contains(lower, "text"), strings.Contains(lower, "clob"):
+		return "TEXT"
+	case strings.Contains(lower, "json"):
+		if target == "sqlite" {
+			return "TEXT"
+		}
+		return "JSON"
+	case strings.Contains(lower, "uuid"):
+		switch target {
+		case "postgres":
+			return "UUID"
+		case "mysql":
+			return "CHAR(36)"
+		default:
+			return "TEXT"
+		}
+	case strings.Contains(lower, "timestamp"), strings.Contains(lower, "datetime"):
+		switch target {
+		case "postgres":
+			return "TIMESTAMP"
+		case "mysql":
+			return "DATETIME"
+		default:
+			return "DATETIME"
+		}
+	case strings.HasPrefix(lower, "date"):
+		return "DATE"
+	case strings.HasPrefix(lower, "time"):
+		return "TIME"
+	case strings.Contains(lower, "blob"), strings.Contains(lower, "binary"), strings.Contains(lower, "bytea"):
+		if target == "postgres" {
+			return "BYTEA"
+		}
+		return "BLOB"
+	default:
+		return "TEXT"
+	}
+}
+
+func mapIntegerType(target, size string) string {
+	switch target {
+	case "postgres":
+		switch size {
+		case "big":
+			return "BIGINT"
+		case "small":
+			return "SMALLINT"
+		default:
+			return "INTEGER"
+		}
+	case "mysql":
+		switch size {
+		case "big":
+			return "BIGINT"
+		case "small":
+			return "SMALLINT"
+		default:
+			return "INT"
+		}
+	default:
+		return "INTEGER"
+	}
+}
+
+func mapDecimalType(target, spec string) string {
+	base := "DECIMAL"
+	if target == "postgres" {
+		base = "NUMERIC"
+	}
+	if spec == "" {
+		return base
+	}
+	return fmt.Sprintf("%s(%s)", base, strings.ReplaceAll(spec, " ", ""))
+}
+
+func mapFloatType(target string, wide bool) string {
+	switch target {
+	case "postgres":
+		if wide {
+			return "DOUBLE PRECISION"
+		}
+		return "REAL"
+	case "mysql":
+		if wide {
+			return "DOUBLE"
+		}
+		return "FLOAT"
+	default:
+		return "REAL"
+	}
+}
+
+func isIntegerType(columnType string) bool {
+	lower := strings.ToLower(columnType)
+	return strings.Contains(lower, "int")
 }
 
 func formatValue(v sql.NullString, colType *sql.ColumnType) string {
 	if !v.Valid {
 		return "NULL"
 	}
+
 	typeName := strings.ToLower(colType.DatabaseTypeName())
 	switch {
-	case strings.Contains(typeName, "int"), strings.Contains(typeName, "float"), strings.Contains(typeName, "double"), strings.Contains(typeName, "dec"):
+	case strings.Contains(typeName, "int"), strings.Contains(typeName, "float"), strings.Contains(typeName, "double"), strings.Contains(typeName, "dec"), strings.Contains(typeName, "numeric"), strings.Contains(typeName, "real"):
 		return v.String
 	case strings.Contains(typeName, "bool"):
 		if v.String == "t" || strings.EqualFold(v.String, "true") || v.String == "1" {
@@ -107,4 +920,31 @@ func formatValue(v sql.NullString, colType *sql.ColumnType) string {
 
 func escapeQuotes(s string) string {
 	return strings.ReplaceAll(s, "'", "''")
+}
+
+func newTraceLogger(enabled bool) traceLogger {
+	if !enabled {
+		return func(string, ...interface{}) {}
+	}
+	return func(format string, args ...interface{}) {
+		fmt.Fprintf(os.Stderr, "[tracesql] "+format+"\n", args...)
+	}
+}
+
+func summarizeRowsByTable(rowsByTable map[string][]scannedRow) string {
+	if len(rowsByTable) == 0 {
+		return "nenhuma tabela"
+	}
+
+	tables := make([]string, 0, len(rowsByTable))
+	for tableName := range rowsByTable {
+		tables = append(tables, tableName)
+	}
+	sort.Strings(tables)
+
+	parts := make([]string, 0, len(tables))
+	for _, tableName := range tables {
+		parts = append(parts, fmt.Sprintf("%s=%d", tableName, len(rowsByTable[tableName])))
+	}
+	return strings.Join(parts, ", ")
 }

--- a/internal/export/exporter_related_test.go
+++ b/internal/export/exporter_related_test.go
@@ -1,0 +1,196 @@
+package export
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Felipe-Cavalca/TraceSQL/internal/config"
+)
+
+func TestRunExportSQLiteParaPostgresIncluiSchemaERelacoesTransitivas(t *testing.T) {
+	db := openSQLiteTestDB(t)
+
+	mustExec(t, db, "PRAGMA foreign_keys = ON")
+	mustExec(t, db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+	mustExec(t, db, "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, total INT, FOREIGN KEY(user_id) REFERENCES users(id))")
+	mustExec(t, db, "CREATE TABLE order_items (id INTEGER PRIMARY KEY, order_id INTEGER, sku TEXT, FOREIGN KEY(order_id) REFERENCES orders(id))")
+	mustExec(t, db, "INSERT INTO users (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+	mustExec(t, db, "INSERT INTO orders (id, user_id, total) VALUES (10, 1, 50), (11, 1, 70), (20, 2, 99)")
+	mustExec(t, db, "INSERT INTO order_items (id, order_id, sku) VALUES (100, 10, 'A-1'), (101, 11, 'A-2'), (200, 20, 'B-1')")
+
+	cfg := config.Config{
+		Driver:       "sqlite",
+		OutputDriver: "postgres",
+		DSN:          "unused",
+		Table:        "orders",
+		Column:       "id",
+		Record:       "10",
+	}
+
+	sqlDump, err := Run(context.Background(), db, cfg)
+	if err != nil {
+		t.Fatalf("erro ao exportar: %v", err)
+	}
+
+	containsAll(t, sqlDump,
+		`CREATE TABLE IF NOT EXISTS "users"`,
+		`CREATE TABLE IF NOT EXISTS "orders"`,
+		`CREATE TABLE IF NOT EXISTS "order_items"`,
+		`FOREIGN KEY ("user_id") REFERENCES "users" ("id")`,
+		`FOREIGN KEY ("order_id") REFERENCES "orders" ("id")`,
+		`INSERT INTO "users" ("id", "name") VALUES (1, 'Alice');`,
+		`INSERT INTO "orders" ("id", "user_id", "total") VALUES (10, 1, 50);`,
+		`INSERT INTO "orders" ("id", "user_id", "total") VALUES (11, 1, 70);`,
+		`INSERT INTO "order_items" ("id", "order_id", "sku") VALUES (100, 10, 'A-1');`,
+		`INSERT INTO "order_items" ("id", "order_id", "sku") VALUES (101, 11, 'A-2');`,
+	)
+
+	if strings.Contains(sqlDump, `'Bob'`) || strings.Contains(sqlDump, "(20, 2, 99)") || strings.Contains(sqlDump, "'B-1'") {
+		t.Fatalf("o dump não deveria incluir registros desconectados do grafo inicial: %s", sqlDump)
+	}
+
+	assertInOrder(t, sqlDump,
+		`CREATE TABLE IF NOT EXISTS "users"`,
+		`CREATE TABLE IF NOT EXISTS "orders"`,
+		`CREATE TABLE IF NOT EXISTS "order_items"`,
+		`INSERT INTO "users"`,
+		`INSERT INTO "orders"`,
+		`INSERT INTO "order_items"`,
+	)
+}
+
+func TestRunExportSQLiteParaMySQLGeraSQLNoDialetoDestino(t *testing.T) {
+	db := openSQLiteTestDB(t)
+
+	mustExec(t, db, "PRAGMA foreign_keys = ON")
+	mustExec(t, db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+	mustExec(t, db, "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, total INT, FOREIGN KEY(user_id) REFERENCES users(id))")
+	mustExec(t, db, "INSERT INTO users (id, name) VALUES (1, 'Alice')")
+	mustExec(t, db, "INSERT INTO orders (id, user_id, total) VALUES (10, 1, 99)")
+
+	cfg := config.Config{
+		Driver:       "sqlite",
+		OutputDriver: "mysql",
+		DSN:          "unused",
+		Table:        "users",
+		Column:       "id",
+		Record:       "1",
+	}
+
+	sqlDump, err := Run(context.Background(), db, cfg)
+	if err != nil {
+		t.Fatalf("erro ao exportar: %v", err)
+	}
+
+	containsAll(t, sqlDump,
+		"CREATE TABLE IF NOT EXISTS `users`",
+		"CREATE TABLE IF NOT EXISTS `orders`",
+		"`id` INT AUTO_INCREMENT NOT NULL",
+		"FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)",
+		"INSERT INTO `users` (`id`, `name`) VALUES (1, 'Alice');",
+		"INSERT INTO `orders` (`id`, `user_id`, `total`) VALUES (10, 1, 99);",
+	)
+
+	if strings.Contains(sqlDump, `"users"`) {
+		t.Fatalf("a saída mysql não deveria usar identificadores no formato postgres: %s", sqlDump)
+	}
+}
+
+func TestRunExportNewIDsComRelacoesNoDestinoSQLite(t *testing.T) {
+	db := openSQLiteTestDB(t)
+
+	mustExec(t, db, "PRAGMA foreign_keys = ON")
+	mustExec(t, db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+	mustExec(t, db, "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, total INT, FOREIGN KEY(user_id) REFERENCES users(id))")
+	mustExec(t, db, "CREATE TABLE order_items (id INTEGER PRIMARY KEY, order_id INTEGER, sku TEXT, FOREIGN KEY(order_id) REFERENCES orders(id))")
+	mustExec(t, db, "INSERT INTO users (id, name) VALUES (1, 'Alice')")
+	mustExec(t, db, "INSERT INTO orders (id, user_id, total) VALUES (10, 1, 99)")
+	mustExec(t, db, "INSERT INTO order_items (id, order_id, sku) VALUES (100, 10, 'A-1')")
+
+	cfg := config.Config{
+		Driver:       "sqlite",
+		OutputDriver: "sqlite",
+		DSN:          "unused",
+		Table:        "users",
+		Column:       "id",
+		Record:       "1",
+		NewIDs:       true,
+	}
+
+	sqlDump, err := Run(context.Background(), db, cfg)
+	if err != nil {
+		t.Fatalf("erro ao exportar com new_ids: %v", err)
+	}
+
+	containsAll(t, sqlDump,
+		"CREATE TEMP TABLE `__tracesql_map_users`",
+		"CREATE TEMP TABLE `__tracesql_map_orders`",
+		"CREATE TEMP TABLE `__tracesql_map_order_items`",
+		"INSERT INTO `users` (`name`) VALUES ('Alice');",
+		"INSERT INTO `__tracesql_map_users` (`old_id`, `new_id`) VALUES (1, last_insert_rowid());",
+		"INSERT INTO `orders` (`user_id`, `total`) VALUES ((SELECT `new_id` FROM `__tracesql_map_users` WHERE `old_id` = 1), 99);",
+		"INSERT INTO `__tracesql_map_orders` (`old_id`, `new_id`) VALUES (10, last_insert_rowid());",
+		"INSERT INTO `order_items` (`order_id`, `sku`) VALUES ((SELECT `new_id` FROM `__tracesql_map_orders` WHERE `old_id` = 10), 'A-1');",
+	)
+}
+
+func TestRunExportNewIDsComRelacoesNoDestinoPostgres(t *testing.T) {
+	db := openSQLiteTestDB(t)
+
+	mustExec(t, db, "PRAGMA foreign_keys = ON")
+	mustExec(t, db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+	mustExec(t, db, "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, total INT, FOREIGN KEY(user_id) REFERENCES users(id))")
+	mustExec(t, db, "INSERT INTO users (id, name) VALUES (1, 'Alice')")
+	mustExec(t, db, "INSERT INTO orders (id, user_id, total) VALUES (10, 1, 99)")
+
+	cfg := config.Config{
+		Driver:       "sqlite",
+		OutputDriver: "postgres",
+		DSN:          "unused",
+		Table:        "users",
+		Column:       "id",
+		Record:       "1",
+		NewIDs:       true,
+	}
+
+	sqlDump, err := Run(context.Background(), db, cfg)
+	if err != nil {
+		t.Fatalf("erro ao exportar com new_ids para postgres: %v", err)
+	}
+
+	containsAll(t, sqlDump,
+		`CREATE TEMP TABLE "__tracesql_map_users"`,
+		`CREATE TEMP TABLE "__tracesql_map_orders"`,
+		`WITH inserted AS (`,
+		`INSERT INTO "users" ("name") VALUES ('Alice') RETURNING "id"`,
+		`INSERT INTO "__tracesql_map_users" ("old_id", "new_id")`,
+		`INSERT INTO "orders" ("user_id", "total") VALUES ((SELECT "new_id" FROM "__tracesql_map_users" WHERE "old_id" = 1), 99) RETURNING "id"`,
+	)
+}
+
+func containsAll(t *testing.T, content string, snippets ...string) {
+	t.Helper()
+
+	for _, snippet := range snippets {
+		if !strings.Contains(content, snippet) {
+			t.Fatalf("trecho não encontrado no dump: %s\n\nDump:\n%s", snippet, content)
+		}
+	}
+}
+
+func assertInOrder(t *testing.T, content string, snippets ...string) {
+	t.Helper()
+
+	lastIndex := -1
+	for _, snippet := range snippets {
+		index := strings.Index(content, snippet)
+		if index == -1 {
+			t.Fatalf("trecho não encontrado no dump: %s\n\nDump:\n%s", snippet, content)
+		}
+		if index < lastIndex {
+			t.Fatalf("ordem inesperada no dump para %s\n\nDump:\n%s", snippet, content)
+		}
+		lastIndex = index
+	}
+}

--- a/internal/export/exporter_test.go
+++ b/internal/export/exporter_test.go
@@ -3,6 +3,7 @@ package export
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -11,22 +12,19 @@ import (
 )
 
 func TestRunExportPreserveIDs(t *testing.T) {
-	db, err := sql.Open("sqlite", "file::memory:?cache=shared")
-	if err != nil {
-		t.Fatalf("abrindo sqlite: %v", err)
-	}
-	t.Cleanup(func() { db.Close() })
+	db := openSQLiteTestDB(t)
 
-	_, _ = db.Exec("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INT)")
-	_, _ = db.Exec("INSERT INTO users (id, name, age) VALUES (1, 'Alice', 30)")
+	mustExec(t, db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, age INT)")
+	mustExec(t, db, "INSERT INTO users (id, name, age) VALUES (1, 'Alice', 30)")
 
 	cfg := config.Config{
-		Driver: "sqlite",
-		DSN:    "file::memory:?cache=shared",
-		Table:  "users",
-		Column: "id",
-		Record: "1",
-		NewIDs: false,
+		Driver:       "sqlite",
+		OutputDriver: "sqlite",
+		DSN:          "unused",
+		Table:        "users",
+		Column:       "id",
+		Record:       "1",
+		NewIDs:       false,
 	}
 
 	sqlDump, err := Run(context.Background(), db, cfg)
@@ -34,28 +32,31 @@ func TestRunExportPreserveIDs(t *testing.T) {
 		t.Fatalf("erro ao exportar: %v", err)
 	}
 
+	if !strings.Contains(sqlDump, "CREATE TABLE IF NOT EXISTS `users`") {
+		t.Fatalf("schema da tabela users não encontrado: %s", sqlDump)
+	}
 	if !strings.Contains(sqlDump, "INSERT INTO `users` (`id`, `name`, `age`) VALUES (1, 'Alice', 30);") {
-		t.Fatalf("SQL inesperado: %s", sqlDump)
+		t.Fatalf("insert da tabela users não encontrado: %s", sqlDump)
+	}
+	if strings.Index(sqlDump, "CREATE TABLE IF NOT EXISTS `users`") > strings.Index(sqlDump, "INSERT INTO `users`") {
+		t.Fatalf("schema deveria aparecer antes do insert: %s", sqlDump)
 	}
 }
 
 func TestRunExportGenerateNewIDs(t *testing.T) {
-	db, err := sql.Open("sqlite", "file::memory:?cache=shared")
-	if err != nil {
-		t.Fatalf("abrindo sqlite: %v", err)
-	}
-	t.Cleanup(func() { db.Close() })
+	db := openSQLiteTestDB(t)
 
-	_, _ = db.Exec("CREATE TABLE orders (id INTEGER PRIMARY KEY, total INT)")
-	_, _ = db.Exec("INSERT INTO orders (id, total) VALUES (10, 99)")
+	mustExec(t, db, "CREATE TABLE orders (id INTEGER PRIMARY KEY, total INT)")
+	mustExec(t, db, "INSERT INTO orders (id, total) VALUES (10, 99)")
 
 	cfg := config.Config{
-		Driver: "sqlite",
-		DSN:    "file::memory:?cache=shared",
-		Table:  "orders",
-		Column: "id",
-		Record: "10",
-		NewIDs: true,
+		Driver:       "sqlite",
+		OutputDriver: "sqlite",
+		DSN:          "unused",
+		Table:        "orders",
+		Column:       "id",
+		Record:       "10",
+		NewIDs:       true,
 	}
 
 	sqlDump, err := Run(context.Background(), db, cfg)
@@ -63,7 +64,30 @@ func TestRunExportGenerateNewIDs(t *testing.T) {
 		t.Fatalf("erro ao exportar: %v", err)
 	}
 
-	if strings.Contains(sqlDump, "`id`") {
-		t.Fatalf("id n?o deveria aparecer quando new_ids = true: %s", sqlDump)
+	if !strings.Contains(sqlDump, "INSERT INTO `orders` (`total`) VALUES (99);") {
+		t.Fatalf("insert deveria omitir a coluna id quando new_ids = true: %s", sqlDump)
+	}
+	if strings.Contains(sqlDump, "INSERT INTO `orders` (`id`,") {
+		t.Fatalf("id não deveria aparecer no insert quando new_ids = true: %s", sqlDump)
+	}
+}
+
+func openSQLiteTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.NewReplacer("/", "_", " ", "_").Replace(t.Name()))
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("abrindo sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func mustExec(t *testing.T, db *sql.DB, query string) {
+	t.Helper()
+
+	if _, err := db.Exec(query); err != nil {
+		t.Fatalf("falha ao executar %q: %v", query, err)
 	}
 }

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -1,3 +1,433 @@
 package metadata
 
-// Placeholder para futura l?gica de descoberta de relacionamentos.
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+type Catalog struct {
+	tables      map[string]Table
+	ForeignKeys []ForeignKey
+}
+
+type Table struct {
+	Name    string
+	Columns []Column
+}
+
+type Column struct {
+	Name          string
+	Type          string
+	Nullable      bool
+	PrimaryKey    bool
+	AutoIncrement bool
+}
+
+type ForeignKey struct {
+	Table     string
+	Column    string
+	RefTable  string
+	RefColumn string
+}
+
+func Discover(ctx context.Context, db *sql.DB, driver string) (Catalog, error) {
+	inspector, err := newInspector(driver)
+	if err != nil {
+		return Catalog{}, err
+	}
+
+	tableNames, err := inspector.listTables(ctx, db)
+	if err != nil {
+		return Catalog{}, err
+	}
+
+	catalog := Catalog{
+		tables: make(map[string]Table, len(tableNames)),
+	}
+
+	for _, tableName := range tableNames {
+		columns, err := inspector.loadColumns(ctx, db, tableName)
+		if err != nil {
+			return Catalog{}, fmt.Errorf("carregando colunas de %s: %w", tableName, err)
+		}
+
+		catalog.tables[strings.ToLower(tableName)] = Table{
+			Name:    tableName,
+			Columns: columns,
+		}
+
+		foreignKeys, err := inspector.loadForeignKeys(ctx, db, tableName)
+		if err != nil {
+			return Catalog{}, fmt.Errorf("carregando chaves estrangeiras de %s: %w", tableName, err)
+		}
+		catalog.ForeignKeys = append(catalog.ForeignKeys, foreignKeys...)
+	}
+
+	sort.Slice(catalog.ForeignKeys, func(i, j int) bool {
+		left := catalog.ForeignKeys[i]
+		right := catalog.ForeignKeys[j]
+		if left.Table != right.Table {
+			return left.Table < right.Table
+		}
+		if left.Column != right.Column {
+			return left.Column < right.Column
+		}
+		if left.RefTable != right.RefTable {
+			return left.RefTable < right.RefTable
+		}
+		return left.RefColumn < right.RefColumn
+	})
+
+	return catalog, nil
+}
+
+func (c Catalog) Table(name string) (Table, bool) {
+	table, ok := c.tables[strings.ToLower(name)]
+	return table, ok
+}
+
+func (c Catalog) TableNames() []string {
+	names := make([]string, 0, len(c.tables))
+	for _, table := range c.tables {
+		names = append(names, table.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func (t Table) PrimaryKeyColumns() []string {
+	var cols []string
+	for _, col := range t.Columns {
+		if col.PrimaryKey {
+			cols = append(cols, col.Name)
+		}
+	}
+	return cols
+}
+
+type inspector interface {
+	listTables(ctx context.Context, db *sql.DB) ([]string, error)
+	loadColumns(ctx context.Context, db *sql.DB, table string) ([]Column, error)
+	loadForeignKeys(ctx context.Context, db *sql.DB, table string) ([]ForeignKey, error)
+}
+
+func newInspector(driver string) (inspector, error) {
+	switch normalizeDriver(driver) {
+	case "sqlite":
+		return sqliteInspector{}, nil
+	case "postgres":
+		return postgresInspector{}, nil
+	case "mysql":
+		return mysqlInspector{}, nil
+	default:
+		return nil, fmt.Errorf("driver não suportado para metadata: %s", driver)
+	}
+}
+
+func normalizeDriver(driver string) string {
+	switch strings.ToLower(driver) {
+	case "postgres", "postgresql", "pg":
+		return "postgres"
+	case "mysql":
+		return "mysql"
+	case "sqlite", "sqlite3":
+		return "sqlite"
+	default:
+		return strings.ToLower(driver)
+	}
+}
+
+type sqliteInspector struct{}
+
+func (sqliteInspector) listTables(ctx context.Context, db *sql.DB) ([]string, error) {
+	rows, err := db.QueryContext(ctx, "SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%' ORDER BY name")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanSingleStringColumn(rows)
+}
+
+func (sqliteInspector) loadColumns(ctx context.Context, db *sql.DB, table string) ([]Column, error) {
+	query := fmt.Sprintf("PRAGMA table_info(%s)", quoteSQLiteIdent(table))
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var columns []Column
+	for rows.Next() {
+		var (
+			cid        int
+			name       string
+			typeName   string
+			notNull    int
+			defaultVal interface{}
+			pk         int
+		)
+		if err := rows.Scan(&cid, &name, &typeName, &notNull, &defaultVal, &pk); err != nil {
+			return nil, err
+		}
+
+		columns = append(columns, Column{
+			Name:          name,
+			Type:          typeName,
+			Nullable:      notNull == 0 && pk == 0,
+			PrimaryKey:    pk > 0,
+			AutoIncrement: pk > 0 && strings.Contains(strings.ToLower(typeName), "int"),
+		})
+	}
+
+	return columns, rows.Err()
+}
+
+func (sqliteInspector) loadForeignKeys(ctx context.Context, db *sql.DB, table string) ([]ForeignKey, error) {
+	query := fmt.Sprintf("PRAGMA foreign_key_list(%s)", quoteSQLiteIdent(table))
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var foreignKeys []ForeignKey
+	for rows.Next() {
+		var (
+			id       int
+			seq      int
+			refTable string
+			fromCol  string
+			toCol    string
+			onUpdate string
+			onDelete string
+			match    string
+		)
+		if err := rows.Scan(&id, &seq, &refTable, &fromCol, &toCol, &onUpdate, &onDelete, &match); err != nil {
+			return nil, err
+		}
+
+		foreignKeys = append(foreignKeys, ForeignKey{
+			Table:     table,
+			Column:    fromCol,
+			RefTable:  refTable,
+			RefColumn: toCol,
+		})
+	}
+
+	return foreignKeys, rows.Err()
+}
+
+type postgresInspector struct{}
+
+func (postgresInspector) listTables(ctx context.Context, db *sql.DB) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT tablename
+FROM pg_catalog.pg_tables
+WHERE schemaname = current_schema()
+ORDER BY tablename`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanSingleStringColumn(rows)
+}
+
+func (postgresInspector) loadColumns(ctx context.Context, db *sql.DB, table string) ([]Column, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT
+  a.attname,
+  pg_catalog.format_type(a.atttypid, a.atttypmod),
+  NOT a.attnotnull AS is_nullable,
+  COALESCE(pg_get_expr(ad.adbin, ad.adrelid), '') AS default_value,
+  EXISTS (
+    SELECT 1
+    FROM pg_index i
+    WHERE i.indrelid = c.oid
+      AND i.indisprimary
+      AND a.attnum = ANY(i.indkey)
+  ) AS is_primary_key,
+  (a.attidentity IN ('a', 'd') OR COALESCE(pg_get_expr(ad.adbin, ad.adrelid), '') LIKE 'nextval(%') AS is_auto_increment
+FROM pg_attribute a
+JOIN pg_class c ON c.oid = a.attrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+LEFT JOIN pg_attrdef ad ON ad.adrelid = a.attrelid AND ad.adnum = a.attnum
+WHERE c.relname = $1
+  AND n.nspname = current_schema()
+  AND a.attnum > 0
+  AND NOT a.attisdropped
+ORDER BY a.attnum`, table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var columns []Column
+	for rows.Next() {
+		var (
+			name       string
+			typeName   string
+			nullable   bool
+			defaultVal sql.NullString
+			primaryKey bool
+			autoInc    bool
+		)
+		if err := rows.Scan(&name, &typeName, &nullable, &defaultVal, &primaryKey, &autoInc); err != nil {
+			return nil, err
+		}
+
+		columns = append(columns, Column{
+			Name:          name,
+			Type:          typeName,
+			Nullable:      nullable,
+			PrimaryKey:    primaryKey,
+			AutoIncrement: autoInc,
+		})
+	}
+
+	return columns, rows.Err()
+}
+
+func (postgresInspector) loadForeignKeys(ctx context.Context, db *sql.DB, table string) ([]ForeignKey, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT
+  tc.table_name,
+  kcu.column_name,
+  ccu.table_name AS referenced_table_name,
+  ccu.column_name AS referenced_column_name
+FROM information_schema.table_constraints tc
+JOIN information_schema.key_column_usage kcu
+  ON tc.constraint_name = kcu.constraint_name
+ AND tc.table_schema = kcu.table_schema
+JOIN information_schema.constraint_column_usage ccu
+  ON ccu.constraint_name = tc.constraint_name
+ AND ccu.table_schema = tc.table_schema
+WHERE tc.constraint_type = 'FOREIGN KEY'
+  AND tc.table_schema = current_schema()
+  AND tc.table_name = $1
+ORDER BY kcu.ordinal_position`, table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var foreignKeys []ForeignKey
+	for rows.Next() {
+		var fk ForeignKey
+		if err := rows.Scan(&fk.Table, &fk.Column, &fk.RefTable, &fk.RefColumn); err != nil {
+			return nil, err
+		}
+		foreignKeys = append(foreignKeys, fk)
+	}
+
+	return foreignKeys, rows.Err()
+}
+
+type mysqlInspector struct{}
+
+func (mysqlInspector) listTables(ctx context.Context, db *sql.DB) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = DATABASE()
+  AND table_type = 'BASE TABLE'
+ORDER BY table_name`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	return scanSingleStringColumn(rows)
+}
+
+func (mysqlInspector) loadColumns(ctx context.Context, db *sql.DB, table string) ([]Column, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT
+  column_name,
+  column_type,
+  is_nullable,
+  column_key,
+  extra
+FROM information_schema.columns
+WHERE table_schema = DATABASE()
+  AND table_name = ?
+ORDER BY ordinal_position`, table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var columns []Column
+	for rows.Next() {
+		var (
+			name       string
+			typeName   string
+			isNullable string
+			columnKey  string
+			extra      string
+		)
+		if err := rows.Scan(&name, &typeName, &isNullable, &columnKey, &extra); err != nil {
+			return nil, err
+		}
+
+		columns = append(columns, Column{
+			Name:          name,
+			Type:          typeName,
+			Nullable:      strings.EqualFold(isNullable, "YES"),
+			PrimaryKey:    strings.EqualFold(columnKey, "PRI"),
+			AutoIncrement: strings.Contains(strings.ToLower(extra), "auto_increment"),
+		})
+	}
+
+	return columns, rows.Err()
+}
+
+func (mysqlInspector) loadForeignKeys(ctx context.Context, db *sql.DB, table string) ([]ForeignKey, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT
+  table_name,
+  column_name,
+  referenced_table_name,
+  referenced_column_name
+FROM information_schema.key_column_usage
+WHERE table_schema = DATABASE()
+  AND table_name = ?
+  AND referenced_table_name IS NOT NULL
+ORDER BY ordinal_position`, table)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var foreignKeys []ForeignKey
+	for rows.Next() {
+		var fk ForeignKey
+		if err := rows.Scan(&fk.Table, &fk.Column, &fk.RefTable, &fk.RefColumn); err != nil {
+			return nil, err
+		}
+		foreignKeys = append(foreignKeys, fk)
+	}
+
+	return foreignKeys, rows.Err()
+}
+
+func scanSingleStringColumn(rows *sql.Rows) ([]string, error) {
+	var values []string
+	for rows.Next() {
+		var value string
+		if err := rows.Scan(&value); err != nil {
+			return nil, err
+		}
+		values = append(values, value)
+	}
+	return values, rows.Err()
+}
+
+func quoteSQLiteIdent(ident string) string {
+	clean := strings.ReplaceAll(ident, `"`, "")
+	return fmt.Sprintf(`"%s"`, clean)
+}

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -1,0 +1,125 @@
+package metadata
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestDiscoverPostgres(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("criando sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectQuery(`SELECT tablename`).
+		WillReturnRows(sqlmock.NewRows([]string{"tablename"}).AddRow("users").AddRow("orders"))
+
+	mock.ExpectQuery(`SELECT\s+a\.attname`).
+		WithArgs("users").
+		WillReturnRows(sqlmock.NewRows([]string{"attname", "format_type", "is_nullable", "default_value", "is_primary_key", "is_auto_increment"}).
+			AddRow("id", "integer", false, "nextval('users_id_seq'::regclass)", true, true).
+			AddRow("name", "text", true, nil, false, false))
+	mock.ExpectQuery(`FROM information_schema\.table_constraints`).
+		WithArgs("users").
+		WillReturnRows(sqlmock.NewRows([]string{"table_name", "column_name", "referenced_table_name", "referenced_column_name"}))
+
+	mock.ExpectQuery(`SELECT\s+a\.attname`).
+		WithArgs("orders").
+		WillReturnRows(sqlmock.NewRows([]string{"attname", "format_type", "is_nullable", "default_value", "is_primary_key", "is_auto_increment"}).
+			AddRow("id", "integer", false, "nextval('orders_id_seq'::regclass)", true, true).
+			AddRow("user_id", "integer", false, nil, false, false).
+			AddRow("total", "integer", false, nil, false, false))
+	mock.ExpectQuery(`FROM information_schema\.table_constraints`).
+		WithArgs("orders").
+		WillReturnRows(sqlmock.NewRows([]string{"table_name", "column_name", "referenced_table_name", "referenced_column_name"}).
+			AddRow("orders", "user_id", "users", "id"))
+
+	catalog, err := Discover(context.Background(), db, "postgres")
+	if err != nil {
+		t.Fatalf("descobrindo metadata postgres: %v", err)
+	}
+
+	users, ok := catalog.Table("users")
+	if !ok {
+		t.Fatal("tabela users não encontrada")
+	}
+	if len(users.Columns) != 2 || !users.Columns[0].PrimaryKey || !users.Columns[0].AutoIncrement {
+		t.Fatalf("metadata de users inesperada: %+v", users.Columns)
+	}
+
+	orders, ok := catalog.Table("orders")
+	if !ok {
+		t.Fatal("tabela orders não encontrada")
+	}
+	if len(orders.Columns) != 3 {
+		t.Fatalf("metadata de orders inesperada: %+v", orders.Columns)
+	}
+	if len(catalog.ForeignKeys) != 1 {
+		t.Fatalf("esperava 1 foreign key, obtive %+v", catalog.ForeignKeys)
+	}
+	if catalog.ForeignKeys[0].Table != "orders" || catalog.ForeignKeys[0].RefTable != "users" {
+		t.Fatalf("foreign key inesperada: %+v", catalog.ForeignKeys[0])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectativas não atendidas: %v", err)
+	}
+}
+
+func TestDiscoverMySQL(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("criando sqlmock: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	mock.ExpectQuery(`FROM information_schema\.tables`).
+		WillReturnRows(sqlmock.NewRows([]string{"table_name"}).AddRow("users").AddRow("orders"))
+
+	mock.ExpectQuery(`FROM information_schema\.columns`).
+		WithArgs("users").
+		WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "is_nullable", "column_key", "extra"}).
+			AddRow("id", "int(11)", "NO", "PRI", "auto_increment").
+			AddRow("name", "varchar(255)", "YES", "", ""))
+	mock.ExpectQuery(`FROM information_schema\.key_column_usage`).
+		WithArgs("users").
+		WillReturnRows(sqlmock.NewRows([]string{"table_name", "column_name", "referenced_table_name", "referenced_column_name"}))
+
+	mock.ExpectQuery(`FROM information_schema\.columns`).
+		WithArgs("orders").
+		WillReturnRows(sqlmock.NewRows([]string{"column_name", "column_type", "is_nullable", "column_key", "extra"}).
+			AddRow("id", "int(11)", "NO", "PRI", "auto_increment").
+			AddRow("user_id", "int(11)", "NO", "", "").
+			AddRow("total", "int(11)", "NO", "", ""))
+	mock.ExpectQuery(`FROM information_schema\.key_column_usage`).
+		WithArgs("orders").
+		WillReturnRows(sqlmock.NewRows([]string{"table_name", "column_name", "referenced_table_name", "referenced_column_name"}).
+			AddRow("orders", "user_id", "users", "id"))
+
+	catalog, err := Discover(context.Background(), db, "mysql")
+	if err != nil {
+		t.Fatalf("descobrindo metadata mysql: %v", err)
+	}
+
+	users, ok := catalog.Table("users")
+	if !ok {
+		t.Fatal("tabela users não encontrada")
+	}
+	if len(users.Columns) != 2 || !users.Columns[0].PrimaryKey || !users.Columns[0].AutoIncrement {
+		t.Fatalf("metadata de users inesperada: %+v", users.Columns)
+	}
+
+	if len(catalog.ForeignKeys) != 1 {
+		t.Fatalf("esperava 1 foreign key, obtive %+v", catalog.ForeignKeys)
+	}
+	if catalog.ForeignKeys[0].Column != "user_id" || catalog.ForeignKeys[0].RefColumn != "id" {
+		t.Fatalf("foreign key inesperada: %+v", catalog.ForeignKeys[0])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectativas não atendidas: %v", err)
+	}
+}

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -16,17 +16,17 @@ func FillMissing(cfg *config.Config, in io.Reader, out io.Writer) error {
 	cfg.Normalize()
 	cfg.EnsureDefaults()
 
-	if cfg.Driver == "" {
+	if !cfg.DriverProvided() && cfg.Driver == "" {
 		fmt.Fprint(out, "Driver (postgres/mysql/sqlite): ")
 		d, _ := reader.ReadString('\n')
 		cfg.Driver = strings.TrimSpace(d)
 	}
-	if cfg.DSN == "" {
+	if !cfg.DSNProvided() && cfg.DSN == "" {
 		fmt.Fprint(out, "DSN de conex?o: ")
 		d, _ := reader.ReadString('\n')
 		cfg.DSN = strings.TrimSpace(d)
 	}
-	if cfg.Table == "" {
+	if !cfg.TableProvided() && cfg.Table == "" {
 		fmt.Fprint(out, "Tabela de origem: ")
 		d, _ := reader.ReadString('\n')
 		cfg.Table = strings.TrimSpace(d)
@@ -34,22 +34,24 @@ func FillMissing(cfg *config.Config, in io.Reader, out io.Writer) error {
 	if cfg.Column == "" {
 		cfg.Column = "id"
 	}
-	if cfg.Column == "id" {
-		fmt.Fprintf(out, "Coluna de refer?ncia [id]: ")
-	} else {
-		fmt.Fprintf(out, "Coluna de refer?ncia [%s]: ", cfg.Column)
-	}
-	if c, _ := reader.ReadString('\n'); strings.TrimSpace(c) != "" {
-		cfg.Column = strings.TrimSpace(c)
+	if !cfg.ColumnProvided() {
+		if cfg.Column == "id" {
+			fmt.Fprintf(out, "Coluna de refer?ncia [id]: ")
+		} else {
+			fmt.Fprintf(out, "Coluna de refer?ncia [%s]: ", cfg.Column)
+		}
+		if c, _ := reader.ReadString('\n'); strings.TrimSpace(c) != "" {
+			cfg.Column = strings.TrimSpace(c)
+		}
 	}
 
-	if cfg.Record == "" {
+	if !cfg.RecordProvided() && cfg.Record == "" {
 		fmt.Fprintf(out, "Valor do registro (%s): ", cfg.Column)
 		d, _ := reader.ReadString('\n')
 		cfg.Record = strings.TrimSpace(d)
 	}
 
-	if !cfg.NewIDs {
+	if !cfg.NewIDsProvided() {
 		fmt.Fprint(out, "Gerar novos IDs? (s/N): ")
 		resp, _ := reader.ReadString('\n')
 		resp = strings.TrimSpace(strings.ToLower(resp))
@@ -57,5 +59,6 @@ func FillMissing(cfg *config.Config, in io.Reader, out io.Writer) error {
 	}
 
 	cfg.Normalize()
+	cfg.EnsureDefaults()
 	return nil
 }

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -1,0 +1,52 @@
+package prompt
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/Felipe-Cavalca/TraceSQL/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func TestFillMissingNaoPerguntaCamposJaInformadosPorFlag(t *testing.T) {
+	cfg := config.Default()
+	cmd := &cobra.Command{Use: "tracesql"}
+	config.AttachFlags(cmd, cfg)
+	args := []string{
+		"--driver", "mysql",
+		"--dsn", "tracesql:tracesql@tcp(127.0.0.1:3307)/tracesql_rich_test",
+		"--table", "orders",
+		"--column", "id",
+		"--record", "1001",
+		"--new-ids=false",
+		"--output-driver", "sqlite",
+		"--log",
+	}
+	cmd.SetArgs(args)
+
+	if err := cmd.ParseFlags(args); err != nil {
+		t.Fatalf("parse flags: %v", err)
+	}
+	if err := config.BindFlags(cmd, &cfg); err != nil {
+		t.Fatalf("bind flags: %v", err)
+	}
+
+	var in bytes.Buffer
+	var out bytes.Buffer
+	if err := FillMissing(&cfg, &in, &out); err != nil {
+		t.Fatalf("fill missing: %v", err)
+	}
+
+	if out.Len() != 0 {
+		t.Fatalf("não deveria ter pedido prompts, mas escreveu: %q", out.String())
+	}
+	if cfg.Column != "id" {
+		t.Fatalf("column inesperada: %s", cfg.Column)
+	}
+	if cfg.NewIDs {
+		t.Fatalf("new_ids deveria permanecer false")
+	}
+	if !cfg.Log {
+		t.Fatalf("log deveria permanecer true")
+	}
+}


### PR DESCRIPTION
## Resumo
Esta PR amplia o TraceSQL para exportar dados e schema entre SQLite, MySQL e PostgreSQL, incluindo descoberta de relacionamentos, geração de SQL no dialeto de destino e suporte a `new_ids` com remapeamento de chaves relacionadas.

## O que mudou
- separação entre driver de origem e dialeto de saída com `--output-driver`
- descoberta de metadata e foreign keys para SQLite, MySQL e PostgreSQL
- geração de `CREATE TABLE IF NOT EXISTS` e `INSERT` para o banco de destino
- suporte a exportação de registros relacionados de forma transitiva
- suporte a `new_ids=true` com tabelas temporárias de mapeamento para preservar relações
- novo parâmetro `--log` para acompanhar a execução no `stderr`
- correção dos prompts para não perguntarem novamente valores já passados por flag
- testes cobrindo metadata, export cruzado e fluxo com `new_ids`

## Motivo
O exportador estava preso à descoberta de relacionamentos em SQLite e ainda tinha fricção no uso via CLI, principalmente quando o usuário já passava tudo por argumento e precisava depurar travamentos sem visibilidade do que estava acontecendo.

## Impacto
Agora fica possível exportar de um banco e inserir em outro com mais previsibilidade, além de diagnosticar a execução com logs quando necessário.

## Validação
- `go test ./...`
- teste manual do binário Windows contra MySQL em container
