### PR TITLE
[codex] melhora configuracao de conexao com banco

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ O histórico das fases do projeto e os próximos passos agora ficam em [ROADMAP.
 ## Requisitos
 - Para uso normal, baixe o binário da Release compatível com seu sistema.
 - Go 1.22+ é necessário apenas se você quiser rodar o projeto a partir do código-fonte.
-- Um DSN válido para o banco de origem.
+- Dados de conexão do banco de origem (`host`, `porta`, `usuário`, `senha` e `banco`) ou um DSN válido.
 - Banco de origem suportado: `postgres`, `mysql` ou `sqlite`.
 
 ## Como usar
@@ -29,7 +29,11 @@ O histórico das fases do projeto e os próximos passos agora ficam em [ROADMAP.
 ```bash
 ./tracesql-linux-amd64 \
   --driver postgres \
-  --dsn 'postgres://user:pass@localhost:5432/app' \
+  --host 127.0.0.1 \
+  --port 5432 \
+  --user user \
+  --password pass \
+  --database app \
   --table orders \
   --column id \
   --record 10 \
@@ -45,7 +49,11 @@ O histórico das fases do projeto e os próximos passos agora ficam em [ROADMAP.
 
 Se algum campo obrigatório não for informado por flag, o CLI pergunta no terminal:
 - driver
-- dsn
+- ip/host
+- porta
+- usuário
+- senha
+- banco
 - tabela de origem
 - coluna de referência
 - valor do registro
@@ -64,7 +72,12 @@ go run ./cmd/tracesql
 | Flag | Obrigatória | Descrição |
 | --- | --- | --- |
 | `--driver` | Sim | Driver do banco de origem: `postgres`, `mysql` ou `sqlite`. |
-| `--dsn` | Sim | String de conexão do banco de origem. |
+| `--dsn` | Não | String de conexão do banco de origem. Continua aceita para compatibilidade ou cenários avançados. |
+| `--host` | Sim* | IP ou host do banco. Obrigatória quando `--dsn` não for informado. |
+| `--port` | Sim* | Porta do banco. Obrigatória quando `--dsn` não for informado. |
+| `--user` | Sim* | Usuário do banco. Obrigatória quando `--dsn` não for informado. |
+| `--password` | Não | Senha do banco. Se não vier por flag ou ambiente, o CLI pergunta interativamente. |
+| `--database` | Sim* | Nome do banco ou caminho do arquivo SQLite. Obrigatória quando `--dsn` não for informado. |
 | `--table` | Sim | Tabela inicial da exportação. |
 | `--record` | Sim | Valor do registro que será usado como ponto de partida. |
 | `--column` | Não | Coluna de referência usada no filtro inicial. Padrão: `id`. |
@@ -81,6 +94,11 @@ O projeto carrega automaticamente um arquivo `.env` na raiz do repositório.
 | --- | --- |
 | `TRACESQL_DRIVER` | Mesmo valor da flag `--driver`. |
 | `TRACESQL_DSN` | Mesmo valor da flag `--dsn`. |
+| `TRACESQL_HOST` | Mesmo valor da flag `--host`. |
+| `TRACESQL_PORT` | Mesmo valor da flag `--port`. |
+| `TRACESQL_USER` | Mesmo valor da flag `--user`. |
+| `TRACESQL_PASSWORD` | Mesmo valor da flag `--password`. |
+| `TRACESQL_DATABASE` | Mesmo valor da flag `--database`. |
 | `TRACESQL_OUTPUT_DRIVER` | Mesmo valor da flag `--output-driver`. |
 | `TRACESQL_NEW_IDS` | Mesmo valor da flag `--new-ids`. Aceita `true`, `1`, `yes`, `sim` e equivalentes. |
 | `TRACESQL_OUT` | Mesmo valor da flag `--out`. |

--- a/cmd/tracesql/main.go
+++ b/cmd/tracesql/main.go
@@ -46,7 +46,12 @@ func main() {
 			}
 			logf("configuração validada")
 
-			database, err := db.Open(cfg.Driver, cfg.DSN)
+			dsn, err := cfg.ConnectionString()
+			if err != nil {
+				return err
+			}
+
+			database, err := db.Open(cfg.Driver, dsn)
 			if err != nil {
 				return err
 			}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,17 +2,25 @@ package config
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 
+	mysql "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
 )
 
-// Config agrupa par?metros de conex?o e exporta??o.
+// Config agrupa parametros de conexao e exportacao.
 type Config struct {
 	Driver       string
 	OutputDriver string
 	DSN          string
+	Host         string
+	Port         string
+	User         string
+	Password     string
+	Database     string
 	Table        string
 	Column       string
 	Record       string
@@ -23,6 +31,11 @@ type Config struct {
 	driverSet       bool
 	outputDriverSet bool
 	dsnSet          bool
+	hostSet         bool
+	portSet         bool
+	userSet         bool
+	passwordSet     bool
+	databaseSet     bool
 	tableSet        bool
 	columnSet       bool
 	recordSet       bool
@@ -31,11 +44,16 @@ type Config struct {
 	logSet          bool
 }
 
-// Default l? valores do ambiente e define padr?es.
+// Default le valores do ambiente e define padroes.
 func Default() Config {
 	driver, driverSet := lookupEnv("TRACESQL_DRIVER")
 	outputDriver, outputDriverSet := lookupEnv("TRACESQL_OUTPUT_DRIVER")
 	dsn, dsnSet := lookupEnv("TRACESQL_DSN")
+	host, hostSet := lookupEnv("TRACESQL_HOST")
+	port, portSet := lookupEnv("TRACESQL_PORT")
+	user, userSet := lookupEnv("TRACESQL_USER")
+	password, passwordSet := lookupEnv("TRACESQL_PASSWORD")
+	database, databaseSet := lookupEnv("TRACESQL_DATABASE")
 	outFile, outFileSet := lookupEnv("TRACESQL_OUT")
 	newIDsRaw, newIDsSet := lookupEnv("TRACESQL_NEW_IDS")
 	logRaw, logSet := lookupEnv("TRACESQL_LOG")
@@ -44,13 +62,23 @@ func Default() Config {
 		Driver:          driver,
 		OutputDriver:    outputDriver,
 		DSN:             dsn,
+		Host:            host,
+		Port:            port,
+		User:            user,
+		Password:        password,
+		Database:        database,
 		Column:          "id",
 		OutFile:         outFile,
-		NewIDs:          strings.EqualFold(newIDsRaw, "true"),
+		NewIDs:          parseBool(newIDsRaw),
 		Log:             parseBool(logRaw),
 		driverSet:       driverSet,
 		outputDriverSet: outputDriverSet,
 		dsnSet:          dsnSet,
+		hostSet:         hostSet,
+		portSet:         portSet,
+		userSet:         userSet,
+		passwordSet:     passwordSet,
+		databaseSet:     databaseSet,
 		outFileSet:      outFileSet,
 		newIDsSet:       newIDsSet,
 		logSet:          logSet,
@@ -61,13 +89,18 @@ func Default() Config {
 func AttachFlags(cmd *cobra.Command, cfg Config) {
 	cmd.PersistentFlags().String("driver", cfg.Driver, "Driver do banco (postgres, mysql, sqlite)")
 	cmd.PersistentFlags().String("output-driver", cfg.OutputDriver, "Dialeto do SQL gerado (padrao: mesmo driver da origem)")
-	cmd.PersistentFlags().String("dsn", cfg.DSN, "DSN de conex?o do banco")
+	cmd.PersistentFlags().String("dsn", cfg.DSN, "DSN de conexao do banco (opcional se host/port/user/password/database forem informados)")
+	cmd.PersistentFlags().String("host", cfg.Host, "IP ou host do banco")
+	cmd.PersistentFlags().String("port", cfg.Port, "Porta do banco")
+	cmd.PersistentFlags().String("user", cfg.User, "Usuario do banco")
+	cmd.PersistentFlags().String("password", cfg.Password, "Senha do banco")
+	cmd.PersistentFlags().String("database", cfg.Database, "Nome do banco ou caminho do arquivo SQLite")
 	cmd.PersistentFlags().String("table", cfg.Table, "Tabela de origem")
-	cmd.PersistentFlags().String("column", cfg.Column, "Coluna de refer?ncia (padr?o id)")
+	cmd.PersistentFlags().String("column", cfg.Column, "Coluna de referencia (padrao id)")
 	cmd.PersistentFlags().String("record", cfg.Record, "Valor do registro a exportar")
 	cmd.PersistentFlags().String("out", cfg.OutFile, "Caminho do arquivo .sql a gerar")
-	cmd.PersistentFlags().Bool("new-ids", cfg.NewIDs, "Gerar novos IDs (omite a coluna de refer?ncia no insert)")
-	cmd.PersistentFlags().Bool("log", cfg.Log, "Exibe logs de execução no stderr")
+	cmd.PersistentFlags().Bool("new-ids", cfg.NewIDs, "Gerar novos IDs (omite a coluna de referencia no insert)")
+	cmd.PersistentFlags().Bool("log", cfg.Log, "Exibe logs de execucao no stderr")
 }
 
 // BindFlags aplica os valores das flags na config.
@@ -77,68 +110,83 @@ func BindFlags(cmd *cobra.Command, cfg *Config) error {
 	if flags.Changed("driver") {
 		cfg.driverSet = true
 	}
-	if v, err := flags.GetString("driver"); err == nil && v != "" {
-		cfg.Driver = v
-	}
+	cfg.Driver, _ = flags.GetString("driver")
+
 	if flags.Changed("output-driver") {
 		cfg.outputDriverSet = true
 	}
-	if v, err := flags.GetString("output-driver"); err == nil && v != "" {
-		cfg.OutputDriver = v
-	}
+	cfg.OutputDriver, _ = flags.GetString("output-driver")
+
 	if flags.Changed("dsn") {
 		cfg.dsnSet = true
 	}
-	if v, err := flags.GetString("dsn"); err == nil && v != "" {
-		cfg.DSN = v
+	cfg.DSN, _ = flags.GetString("dsn")
+
+	if flags.Changed("host") {
+		cfg.hostSet = true
 	}
+	cfg.Host, _ = flags.GetString("host")
+
+	if flags.Changed("port") {
+		cfg.portSet = true
+	}
+	cfg.Port, _ = flags.GetString("port")
+
+	if flags.Changed("user") {
+		cfg.userSet = true
+	}
+	cfg.User, _ = flags.GetString("user")
+
+	if flags.Changed("password") {
+		cfg.passwordSet = true
+	}
+	cfg.Password, _ = flags.GetString("password")
+
+	if flags.Changed("database") {
+		cfg.databaseSet = true
+	}
+	cfg.Database, _ = flags.GetString("database")
+
 	if flags.Changed("table") {
 		cfg.tableSet = true
 	}
-	if v, err := flags.GetString("table"); err == nil && v != "" {
-		cfg.Table = v
-	}
+	cfg.Table, _ = flags.GetString("table")
+
 	if flags.Changed("column") {
 		cfg.columnSet = true
 	}
-	if v, err := flags.GetString("column"); err == nil && v != "" {
-		cfg.Column = v
-	}
+	cfg.Column, _ = flags.GetString("column")
+
 	if flags.Changed("record") {
 		cfg.recordSet = true
 	}
-	if v, err := flags.GetString("record"); err == nil && v != "" {
-		cfg.Record = v
-	}
+	cfg.Record, _ = flags.GetString("record")
+
 	if flags.Changed("out") {
 		cfg.outFileSet = true
 	}
-	if v, err := flags.GetString("out"); err == nil && v != "" {
-		cfg.OutFile = v
-	}
+	cfg.OutFile, _ = flags.GetString("out")
+
 	if flags.Changed("new-ids") {
 		cfg.newIDsSet = true
 	}
-	if v, err := flags.GetBool("new-ids"); err == nil {
-		cfg.NewIDs = v
-	}
+	cfg.NewIDs, _ = flags.GetBool("new-ids")
+
 	if flags.Changed("log") {
 		cfg.logSet = true
 	}
-	if v, err := flags.GetBool("log"); err == nil {
-		cfg.Log = v
-	}
+	cfg.Log, _ = flags.GetBool("log")
+
 	return nil
 }
 
-// Validate garante que campos obrigat?rios foram fornecidos.
+// Validate garante que campos obrigatorios foram fornecidos.
 func (c Config) Validate() error {
+	c.Normalize()
+
 	missing := []string{}
 	if c.Driver == "" {
 		missing = append(missing, "driver")
-	}
-	if c.DSN == "" {
-		missing = append(missing, "dsn")
 	}
 	if c.Table == "" {
 		missing = append(missing, "table")
@@ -146,13 +194,38 @@ func (c Config) Validate() error {
 	if c.Record == "" {
 		missing = append(missing, "record")
 	}
+
+	if strings.TrimSpace(c.DSN) == "" {
+		switch c.Driver {
+		case "postgres", "mysql":
+			if c.Host == "" {
+				missing = append(missing, "host")
+			}
+			if c.Port == "" {
+				missing = append(missing, "port")
+			}
+			if c.User == "" {
+				missing = append(missing, "user")
+			}
+			if c.Database == "" {
+				missing = append(missing, "database")
+			}
+		case "sqlite":
+			if c.Database == "" {
+				missing = append(missing, "database")
+			}
+		default:
+			missing = append(missing, "dsn")
+		}
+	}
+
 	if len(missing) > 0 {
-		return fmt.Errorf("campos obrigat?rios faltando: %s", strings.Join(missing, ", "))
+		return fmt.Errorf("campos obrigatorios faltando: %s", strings.Join(missing, ", "))
 	}
 	return nil
 }
 
-// OutPath resolve o caminho de sa?da.
+// OutPath resolve o caminho de saida.
 func (c Config) OutPath() string {
 	if c.OutFile != "" {
 		return c.OutFile
@@ -184,6 +257,26 @@ func (c *Config) WithPrompts(values map[string]string) {
 		c.DSN = values["dsn"]
 		c.dsnSet = c.DSN != ""
 	}
+	if c.Host == "" {
+		c.Host = values["host"]
+		c.hostSet = c.Host != ""
+	}
+	if c.Port == "" {
+		c.Port = values["port"]
+		c.portSet = c.Port != ""
+	}
+	if c.User == "" {
+		c.User = values["user"]
+		c.userSet = c.User != ""
+	}
+	if c.Password == "" {
+		c.Password = values["password"]
+		c.passwordSet = c.Password != ""
+	}
+	if c.Database == "" {
+		c.Database = values["database"]
+		c.databaseSet = c.Database != ""
+	}
 	if c.Table == "" {
 		c.Table = values["table"]
 		c.tableSet = c.Table != ""
@@ -197,7 +290,7 @@ func (c *Config) WithPrompts(values map[string]string) {
 	}
 }
 
-// Normalize reduz abrevia??es dos drivers.
+// Normalize reduz abreviacoes dos drivers.
 func (c *Config) Normalize() {
 	switch strings.ToLower(c.Driver) {
 	case "postgres", "postgresql", "pg":
@@ -241,6 +334,26 @@ func (c Config) DSNProvided() bool {
 	return c.dsnSet
 }
 
+func (c Config) HostProvided() bool {
+	return c.hostSet
+}
+
+func (c Config) PortProvided() bool {
+	return c.portSet
+}
+
+func (c Config) UserProvided() bool {
+	return c.userSet
+}
+
+func (c Config) PasswordProvided() bool {
+	return c.passwordSet
+}
+
+func (c Config) DatabaseProvided() bool {
+	return c.databaseSet
+}
+
 func (c Config) TableProvided() bool {
 	return c.tableSet
 }
@@ -255,6 +368,64 @@ func (c Config) RecordProvided() bool {
 
 func (c Config) NewIDsProvided() bool {
 	return c.newIDsSet
+}
+
+func (c Config) DefaultPort() string {
+	switch strings.ToLower(c.Driver) {
+	case "postgres":
+		return "5432"
+	case "mysql":
+		return "3306"
+	default:
+		return ""
+	}
+}
+
+// ConnectionString retorna a DSN final usada para abrir a conexao.
+func (c Config) ConnectionString() (string, error) {
+	c.Normalize()
+
+	if strings.TrimSpace(c.DSN) != "" {
+		return c.DSN, nil
+	}
+
+	switch c.Driver {
+	case "postgres":
+		return buildPostgresDSN(c), nil
+	case "mysql":
+		return buildMySQLDSN(c), nil
+	case "sqlite":
+		if c.Database == "" {
+			return "", fmt.Errorf("informe o caminho do banco sqlite em --database ou --dsn")
+		}
+		return c.Database, nil
+	default:
+		return "", fmt.Errorf("driver nao suportado: %s", c.Driver)
+	}
+}
+
+func buildPostgresDSN(c Config) string {
+	u := &url.URL{
+		Scheme: "postgres",
+		Host:   net.JoinHostPort(c.Host, c.Port),
+		Path:   "/" + strings.TrimPrefix(c.Database, "/"),
+	}
+	if c.Password == "" {
+		u.User = url.User(c.User)
+	} else {
+		u.User = url.UserPassword(c.User, c.Password)
+	}
+	return u.String()
+}
+
+func buildMySQLDSN(c Config) string {
+	cfg := mysql.NewConfig()
+	cfg.Net = "tcp"
+	cfg.Addr = net.JoinHostPort(c.Host, c.Port)
+	cfg.User = c.User
+	cfg.Passwd = c.Password
+	cfg.DBName = c.Database
+	return cfg.FormatDSN()
 }
 
 func parseBool(raw string) bool {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/Felipe-Cavalca/TraceSQL/internal/config"
@@ -10,22 +9,29 @@ import (
 func TestDefaultFromEnv(t *testing.T) {
 	t.Setenv("TRACESQL_DRIVER", "postgres")
 	t.Setenv("TRACESQL_OUTPUT_DRIVER", "mysql")
-	t.Setenv("TRACESQL_DSN", "postgres://user:pass@localhost/db")
+	t.Setenv("TRACESQL_HOST", "127.0.0.1")
+	t.Setenv("TRACESQL_PORT", "5432")
+	t.Setenv("TRACESQL_USER", "app")
+	t.Setenv("TRACESQL_PASSWORD", "secret")
+	t.Setenv("TRACESQL_DATABASE", "trace")
 	t.Setenv("TRACESQL_NEW_IDS", "true")
 
 	cfg := config.Default()
 
-	if cfg.Driver != "postgres" || cfg.DSN == "" {
-		t.Fatalf("env não aplicado corretamente: %+v", cfg)
+	if cfg.Driver != "postgres" || cfg.Host != "127.0.0.1" {
+		t.Fatalf("env nao aplicado corretamente: %+v", cfg)
 	}
 	if cfg.OutputDriver != "mysql" {
-		t.Fatalf("output driver não aplicado corretamente: %+v", cfg)
+		t.Fatalf("output driver nao aplicado corretamente: %+v", cfg)
+	}
+	if cfg.Database != "trace" || cfg.User != "app" || cfg.Password != "secret" {
+		t.Fatalf("campos de conexao nao foram carregados: %+v", cfg)
 	}
 	if cfg.Table != "" || cfg.Record != "" {
-		t.Fatalf("table/record não deveriam vir do env: %+v", cfg)
+		t.Fatalf("table/record nao deveriam vir do env: %+v", cfg)
 	}
 	if cfg.Column != "id" {
-		t.Fatalf("coluna padrão deveria ser id, obtido %s", cfg.Column)
+		t.Fatalf("coluna padrao deveria ser id, obtido %s", cfg.Column)
 	}
 	if !cfg.NewIDs {
 		t.Fatalf("flag de novos IDs deveria estar true")
@@ -47,15 +53,30 @@ func TestOutPath(t *testing.T) {
 func TestValidate(t *testing.T) {
 	cfg := config.Config{}
 	if err := cfg.Validate(); err == nil {
-		t.Fatal("deveria falhar sem campos obrigat?rios")
+		t.Fatal("deveria falhar sem campos obrigatorios")
 	}
 
-	cfg.Driver = "sqlite"
-	cfg.DSN = "file::memory:?cache=shared"
-	cfg.Table = "users"
-	cfg.Record = "1"
+	cfg = config.Config{
+		Driver:   "postgres",
+		Host:     "127.0.0.1",
+		Port:     "5432",
+		User:     "app",
+		Database: "trace",
+		Table:    "users",
+		Record:   "1",
+	}
 	if err := cfg.Validate(); err != nil {
-		t.Fatalf("n?o deveria falhar: %v", err)
+		t.Fatalf("nao deveria falhar com conexao em campos separados: %v", err)
+	}
+
+	cfg = config.Config{
+		Driver:   "sqlite",
+		Database: "trace.db",
+		Table:    "users",
+		Record:   "1",
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("nao deveria falhar para sqlite com database: %v", err)
 	}
 }
 
@@ -71,11 +92,79 @@ func TestEnsureDefaults(t *testing.T) {
 	cfg := config.Config{Driver: "sqlite"}
 	cfg.EnsureDefaults()
 	if cfg.Column != "id" {
-		t.Fatalf("coluna padr?o deveria ser id, obtido %s", cfg.Column)
+		t.Fatalf("coluna padrao deveria ser id, obtido %s", cfg.Column)
 	}
 	if cfg.OutputDriver != "sqlite" {
-		t.Fatalf("output driver padrão deveria seguir o driver, obtido %s", cfg.OutputDriver)
+		t.Fatalf("output driver padrao deveria seguir o driver, obtido %s", cfg.OutputDriver)
+	}
+}
+
+func TestConnectionStringPrefersDSN(t *testing.T) {
+	cfg := config.Config{
+		Driver: "postgres",
+		DSN:    "postgres://user:pass@localhost:5432/app",
 	}
 
-	os.Unsetenv("TRACESQL_COLUMN")
+	dsn, err := cfg.ConnectionString()
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	if dsn != cfg.DSN {
+		t.Fatalf("esperado usar a DSN original, obtido %q", dsn)
+	}
+}
+
+func TestConnectionStringPostgres(t *testing.T) {
+	cfg := config.Config{
+		Driver:   "postgres",
+		Host:     "127.0.0.1",
+		Port:     "5432",
+		User:     "app",
+		Password: "secret",
+		Database: "trace",
+	}
+
+	dsn, err := cfg.ConnectionString()
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	expected := "postgres://app:secret@127.0.0.1:5432/trace"
+	if dsn != expected {
+		t.Fatalf("dsn inesperada: %s", dsn)
+	}
+}
+
+func TestConnectionStringMySQL(t *testing.T) {
+	cfg := config.Config{
+		Driver:   "mysql",
+		Host:     "127.0.0.1",
+		Port:     "3306",
+		User:     "app",
+		Password: "secret",
+		Database: "trace",
+	}
+
+	dsn, err := cfg.ConnectionString()
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	expected := "app:secret@tcp(127.0.0.1:3306)/trace"
+	if dsn != expected {
+		t.Fatalf("dsn inesperada: %s", dsn)
+	}
+}
+
+func TestConnectionStringSQLite(t *testing.T) {
+	cfg := config.Config{
+		Driver:   "sqlite",
+		Database: "trace.db",
+	}
+
+	dsn, err := cfg.ConnectionString()
+	if err != nil {
+		t.Fatalf("connection string: %v", err)
+	}
+	if dsn != "trace.db" {
+		t.Fatalf("dsn inesperada: %s", dsn)
+	}
 }

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -18,47 +18,93 @@ func FillMissing(cfg *config.Config, in io.Reader, out io.Writer) error {
 
 	if !cfg.DriverProvided() && cfg.Driver == "" {
 		fmt.Fprint(out, "Driver (postgres/mysql/sqlite): ")
-		d, _ := reader.ReadString('\n')
-		cfg.Driver = strings.TrimSpace(d)
+		cfg.Driver = readLine(reader)
 	}
+
+	cfg.Normalize()
+	cfg.EnsureDefaults()
+
 	if !cfg.DSNProvided() && cfg.DSN == "" {
-		fmt.Fprint(out, "DSN de conex?o: ")
-		d, _ := reader.ReadString('\n')
-		cfg.DSN = strings.TrimSpace(d)
+		switch cfg.Driver {
+		case "postgres", "mysql":
+			if !cfg.HostProvided() && cfg.Host == "" {
+				fmt.Fprint(out, "IP ou host do banco: ")
+				cfg.Host = readLine(reader)
+			}
+			if !cfg.PortProvided() && cfg.Port == "" {
+				cfg.Port = promptWithDefault(reader, out, "Porta do banco", cfg.DefaultPort())
+			}
+			if !cfg.UserProvided() && cfg.User == "" {
+				fmt.Fprint(out, "Usuario do banco: ")
+				cfg.User = readLine(reader)
+			}
+			if !cfg.PasswordProvided() && cfg.Password == "" {
+				fmt.Fprint(out, "Senha do banco: ")
+				cfg.Password = readLine(reader)
+			}
+			if !cfg.DatabaseProvided() && cfg.Database == "" {
+				fmt.Fprint(out, "Nome do banco: ")
+				cfg.Database = readLine(reader)
+			}
+		case "sqlite":
+			if !cfg.DatabaseProvided() && cfg.Database == "" {
+				fmt.Fprint(out, "Caminho do banco SQLite: ")
+				cfg.Database = readLine(reader)
+			}
+		default:
+			fmt.Fprint(out, "DSN de conexao: ")
+			cfg.DSN = readLine(reader)
+		}
 	}
+
 	if !cfg.TableProvided() && cfg.Table == "" {
 		fmt.Fprint(out, "Tabela de origem: ")
-		d, _ := reader.ReadString('\n')
-		cfg.Table = strings.TrimSpace(d)
+		cfg.Table = readLine(reader)
 	}
 	if cfg.Column == "" {
 		cfg.Column = "id"
 	}
 	if !cfg.ColumnProvided() {
 		if cfg.Column == "id" {
-			fmt.Fprintf(out, "Coluna de refer?ncia [id]: ")
+			fmt.Fprint(out, "Coluna de referencia [id]: ")
 		} else {
-			fmt.Fprintf(out, "Coluna de refer?ncia [%s]: ", cfg.Column)
+			fmt.Fprintf(out, "Coluna de referencia [%s]: ", cfg.Column)
 		}
-		if c, _ := reader.ReadString('\n'); strings.TrimSpace(c) != "" {
-			cfg.Column = strings.TrimSpace(c)
+		if c := readLine(reader); c != "" {
+			cfg.Column = c
 		}
 	}
 
 	if !cfg.RecordProvided() && cfg.Record == "" {
 		fmt.Fprintf(out, "Valor do registro (%s): ", cfg.Column)
-		d, _ := reader.ReadString('\n')
-		cfg.Record = strings.TrimSpace(d)
+		cfg.Record = readLine(reader)
 	}
 
 	if !cfg.NewIDsProvided() {
 		fmt.Fprint(out, "Gerar novos IDs? (s/N): ")
-		resp, _ := reader.ReadString('\n')
-		resp = strings.TrimSpace(strings.ToLower(resp))
+		resp := strings.ToLower(readLine(reader))
 		cfg.NewIDs = resp == "s" || resp == "y" || resp == "sim"
 	}
 
 	cfg.Normalize()
 	cfg.EnsureDefaults()
 	return nil
+}
+
+func readLine(reader *bufio.Reader) string {
+	value, _ := reader.ReadString('\n')
+	return strings.TrimSpace(value)
+}
+
+func promptWithDefault(reader *bufio.Reader, out io.Writer, label, fallback string) string {
+	if fallback == "" {
+		fmt.Fprintf(out, "%s: ", label)
+		return readLine(reader)
+	}
+
+	fmt.Fprintf(out, "%s [%s]: ", label, fallback)
+	if value := readLine(reader); value != "" {
+		return value
+	}
+	return fallback
 }

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -2,6 +2,7 @@ package prompt
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/Felipe-Cavalca/TraceSQL/internal/config"
@@ -14,7 +15,11 @@ func TestFillMissingNaoPerguntaCamposJaInformadosPorFlag(t *testing.T) {
 	config.AttachFlags(cmd, cfg)
 	args := []string{
 		"--driver", "mysql",
-		"--dsn", "tracesql:tracesql@tcp(127.0.0.1:3307)/tracesql_rich_test",
+		"--host", "127.0.0.1",
+		"--port", "3307",
+		"--user", "tracesql",
+		"--password", "tracesql",
+		"--database", "tracesql_rich_test",
 		"--table", "orders",
 		"--column", "id",
 		"--record", "1001",
@@ -38,7 +43,7 @@ func TestFillMissingNaoPerguntaCamposJaInformadosPorFlag(t *testing.T) {
 	}
 
 	if out.Len() != 0 {
-		t.Fatalf("não deveria ter pedido prompts, mas escreveu: %q", out.String())
+		t.Fatalf("nao deveria ter pedido prompts, mas escreveu: %q", out.String())
 	}
 	if cfg.Column != "id" {
 		t.Fatalf("column inesperada: %s", cfg.Column)
@@ -48,5 +53,64 @@ func TestFillMissingNaoPerguntaCamposJaInformadosPorFlag(t *testing.T) {
 	}
 	if !cfg.Log {
 		t.Fatalf("log deveria permanecer true")
+	}
+}
+
+func TestFillMissingPerguntaCamposDeConexaoSeparados(t *testing.T) {
+	cfg := config.Default()
+
+	input := strings.Join([]string{
+		"postgres",
+		"127.0.0.1",
+		"",
+		"app_user",
+		"secret",
+		"trace_db",
+		"orders",
+		"",
+		"1001",
+		"s",
+	}, "\n") + "\n"
+
+	var in bytes.Buffer
+	in.WriteString(input)
+	var out bytes.Buffer
+
+	if err := FillMissing(&cfg, &in, &out); err != nil {
+		t.Fatalf("fill missing: %v", err)
+	}
+
+	if cfg.Driver != "postgres" {
+		t.Fatalf("driver inesperado: %s", cfg.Driver)
+	}
+	if cfg.Host != "127.0.0.1" || cfg.Port != "5432" {
+		t.Fatalf("conexao inesperada: host=%s port=%s", cfg.Host, cfg.Port)
+	}
+	if cfg.User != "app_user" || cfg.Password != "secret" || cfg.Database != "trace_db" {
+		t.Fatalf("credenciais inesperadas: %+v", cfg)
+	}
+	if cfg.Table != "orders" || cfg.Column != "id" || cfg.Record != "1001" {
+		t.Fatalf("dados de exportacao inesperados: %+v", cfg)
+	}
+	if !cfg.NewIDs {
+		t.Fatalf("new_ids deveria ser true")
+	}
+
+	written := out.String()
+	for _, expected := range []string{
+		"Driver (postgres/mysql/sqlite): ",
+		"IP ou host do banco: ",
+		"Porta do banco [5432]: ",
+		"Usuario do banco: ",
+		"Senha do banco: ",
+		"Nome do banco: ",
+		"Tabela de origem: ",
+		"Coluna de referencia [id]: ",
+		"Valor do registro (id): ",
+		"Gerar novos IDs? (s/N): ",
+	} {
+		if !strings.Contains(written, expected) {
+			t.Fatalf("prompt nao encontrado: %q em %q", expected, written)
+		}
 	}
 }


### PR DESCRIPTION
## O que mudou
- substitui a dependência exclusiva de `--dsn` por parâmetros separados de conexão (`--host`, `--port`, `--user`, `--password` e `--database`)
- passa a montar a string de conexão automaticamente para `postgres`, `mysql` e `sqlite`
- atualiza os prompts interativos para pedir os dados faltantes na inicialização
- mantém compatibilidade com `--dsn` para cenários existentes
- ajusta a documentação e amplia a cobertura de testes para o novo fluxo

## Por que mudou
O CLI exigia uma string de conexão completa mesmo em cenários simples. Isso tornava a inicialização menos amigável e atrapalhava o uso interativo quando o usuário só tinha os dados básicos do banco.

## Impacto
- melhora a experiência de uso do CLI
- permite informar dados de conexão de forma guiada
- preserva compatibilidade com quem já usa `--dsn`

## Validação
- `go test ./...`
