### PR TITLE
[codex] Adiciona relacoes por nome na exportacao

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 ﻿# TraceSQL
 
-`TraceSQL` é um CLI em Go para exportar um registro e o seu grafo relacional para um arquivo `.sql`. Ele conecta em bancos `postgres`, `mysql` ou `sqlite`, descobre relacionamentos por chave estrangeira, gera o schema das tabelas envolvidas e escreve os `INSERT`s no dialeto de saída escolhido.
+`TraceSQL` é um CLI em Go para exportar um registro e o seu grafo relacional para um arquivo `.sql`. Ele conecta em bancos `postgres`, `mysql` ou `sqlite`, descobre relacionamentos por chave estrangeira e também pode inferi-los por nome, gera o schema das tabelas envolvidas e escreve os `INSERT`s no dialeto de saída escolhido.
 
 O histórico das fases do projeto e os próximos passos agora ficam em [ROADMAP.md](ROADMAP.md).
 
 ## O que o projeto faz
 - Exporta um registro base a partir de `tabela`, `coluna` e `valor`.
 - Descobre relações pai/filho via foreign keys e inclui os registros conectados.
+- Opcionalmente infere relações pelo padrão `[tabela]_id`, útil quando o banco não tem foreign keys declaradas.
 - Gera `CREATE TABLE IF NOT EXISTS` e `INSERT`s no dialeto `postgres`, `mysql` ou `sqlite`.
 - Permite manter os IDs originais ou regenerá-los quando a tabela usa chave primária auto increment.
 - Aceita configuração por `.env`, flags e prompts interativos no terminal.
@@ -84,6 +85,7 @@ go run ./cmd/tracesql
 | `--output-driver` | Não | Dialeto SQL de saída. Padrão: mesmo driver da origem. |
 | `--out` | Não | Caminho do arquivo `.sql` gerado. |
 | `--new-ids` | Não | Omite a chave de referência dos `INSERT`s para gerar novos IDs quando suportado. |
+| `--relations-by-name` | Não | Infere relações pelo padrão `[tabela]_id` e adiciona essas referências ao grafo exportado. |
 | `--log` | Não | Escreve logs de execução no `stderr`. |
 
 ## Variáveis de ambiente suportadas
@@ -101,6 +103,7 @@ O projeto carrega automaticamente um arquivo `.env` na raiz do repositório.
 | `TRACESQL_DATABASE` | Mesmo valor da flag `--database`. |
 | `TRACESQL_OUTPUT_DRIVER` | Mesmo valor da flag `--output-driver`. |
 | `TRACESQL_NEW_IDS` | Mesmo valor da flag `--new-ids`. Aceita `true`, `1`, `yes`, `sim` e equivalentes. |
+| `TRACESQL_RELATIONS_BY_NAME` | Mesmo valor da flag `--relations-by-name`. Aceita `true`, `1`, `yes`, `sim` e equivalentes. |
 | `TRACESQL_OUT` | Mesmo valor da flag `--out`. |
 | `TRACESQL_LOG` | Mesmo valor da flag `--log`. |
 
@@ -108,6 +111,7 @@ O projeto carrega automaticamente um arquivo `.env` na raiz do repositório.
 - Nome padrão: `export_<tabela>_<registro>.sql`.
 - Conteúdo: `CREATE TABLE IF NOT EXISTS` seguido dos `INSERT`s das linhas exportadas.
 - Quando `--new-ids` está ativo, o TraceSQL cria mapeamentos temporários para preservar referências entre tabelas relacionadas.
+- Quando `--relations-by-name` está ativo, o TraceSQL também tenta relacionar tabelas por colunas no formato `[tabela]_id`, sem substituir foreign keys reais já existentes.
 
 ## Desenvolvimento
 - Dev Container em `.devcontainer/` com Go 1.22, SQLite, clientes MySQL/Postgres e Docker socket para testes.

--- a/cmd/tracesql/main.go
+++ b/cmd/tracesql/main.go
@@ -34,7 +34,7 @@ func main() {
 			if err := config.BindFlags(cmd, &cfg); err != nil {
 				return err
 			}
-			logf("configuração carregada: origem=%s destino=%s tabela=%s coluna=%s registro=%s new_ids=%t", cfg.Driver, cfg.OutputDriver, cfg.Table, cfg.Column, cfg.Record, cfg.NewIDs)
+			logf("configuração carregada: origem=%s destino=%s tabela=%s coluna=%s registro=%s new_ids=%t relations_by_name=%t", cfg.Driver, cfg.OutputDriver, cfg.Table, cfg.Column, cfg.Record, cfg.NewIDs, cfg.RelationsByName)
 
 			if err := prompt.FillMissing(&cfg, os.Stdin, os.Stdout); err != nil {
 				return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,35 +13,37 @@ import (
 
 // Config agrupa parametros de conexao e exportacao.
 type Config struct {
-	Driver       string
-	OutputDriver string
-	DSN          string
-	Host         string
-	Port         string
-	User         string
-	Password     string
-	Database     string
-	Table        string
-	Column       string
-	Record       string
-	OutFile      string
-	NewIDs       bool
-	Log          bool
+	Driver          string
+	OutputDriver    string
+	DSN             string
+	Host            string
+	Port            string
+	User            string
+	Password        string
+	Database        string
+	Table           string
+	Column          string
+	Record          string
+	OutFile         string
+	NewIDs          bool
+	RelationsByName bool
+	Log             bool
 
-	driverSet       bool
-	outputDriverSet bool
-	dsnSet          bool
-	hostSet         bool
-	portSet         bool
-	userSet         bool
-	passwordSet     bool
-	databaseSet     bool
-	tableSet        bool
-	columnSet       bool
-	recordSet       bool
-	outFileSet      bool
-	newIDsSet       bool
-	logSet          bool
+	driverSet          bool
+	outputDriverSet    bool
+	dsnSet             bool
+	hostSet            bool
+	portSet            bool
+	userSet            bool
+	passwordSet        bool
+	databaseSet        bool
+	tableSet           bool
+	columnSet          bool
+	recordSet          bool
+	outFileSet         bool
+	newIDsSet          bool
+	relationsByNameSet bool
+	logSet             bool
 }
 
 // Default le valores do ambiente e define padroes.
@@ -56,32 +58,35 @@ func Default() Config {
 	database, databaseSet := lookupEnv("TRACESQL_DATABASE")
 	outFile, outFileSet := lookupEnv("TRACESQL_OUT")
 	newIDsRaw, newIDsSet := lookupEnv("TRACESQL_NEW_IDS")
+	relationsByNameRaw, relationsByNameSet := lookupEnv("TRACESQL_RELATIONS_BY_NAME")
 	logRaw, logSet := lookupEnv("TRACESQL_LOG")
 
 	return Config{
-		Driver:          driver,
-		OutputDriver:    outputDriver,
-		DSN:             dsn,
-		Host:            host,
-		Port:            port,
-		User:            user,
-		Password:        password,
-		Database:        database,
-		Column:          "id",
-		OutFile:         outFile,
-		NewIDs:          parseBool(newIDsRaw),
-		Log:             parseBool(logRaw),
-		driverSet:       driverSet,
-		outputDriverSet: outputDriverSet,
-		dsnSet:          dsnSet,
-		hostSet:         hostSet,
-		portSet:         portSet,
-		userSet:         userSet,
-		passwordSet:     passwordSet,
-		databaseSet:     databaseSet,
-		outFileSet:      outFileSet,
-		newIDsSet:       newIDsSet,
-		logSet:          logSet,
+		Driver:             driver,
+		OutputDriver:       outputDriver,
+		DSN:                dsn,
+		Host:               host,
+		Port:               port,
+		User:               user,
+		Password:           password,
+		Database:           database,
+		Column:             "id",
+		OutFile:            outFile,
+		NewIDs:             parseBool(newIDsRaw),
+		RelationsByName:    parseBool(relationsByNameRaw),
+		Log:                parseBool(logRaw),
+		driverSet:          driverSet,
+		outputDriverSet:    outputDriverSet,
+		dsnSet:             dsnSet,
+		hostSet:            hostSet,
+		portSet:            portSet,
+		userSet:            userSet,
+		passwordSet:        passwordSet,
+		databaseSet:        databaseSet,
+		outFileSet:         outFileSet,
+		newIDsSet:          newIDsSet,
+		relationsByNameSet: relationsByNameSet,
+		logSet:             logSet,
 	}
 }
 
@@ -100,6 +105,7 @@ func AttachFlags(cmd *cobra.Command, cfg Config) {
 	cmd.PersistentFlags().String("record", cfg.Record, "Valor do registro a exportar")
 	cmd.PersistentFlags().String("out", cfg.OutFile, "Caminho do arquivo .sql a gerar")
 	cmd.PersistentFlags().Bool("new-ids", cfg.NewIDs, "Gerar novos IDs (omite a coluna de referencia no insert)")
+	cmd.PersistentFlags().Bool("relations-by-name", cfg.RelationsByName, "Infere relacoes pelo padrao [tabela]_id quando nao houver foreign key")
 	cmd.PersistentFlags().Bool("log", cfg.Log, "Exibe logs de execucao no stderr")
 }
 
@@ -171,6 +177,11 @@ func BindFlags(cmd *cobra.Command, cfg *Config) error {
 		cfg.newIDsSet = true
 	}
 	cfg.NewIDs, _ = flags.GetBool("new-ids")
+
+	if flags.Changed("relations-by-name") {
+		cfg.relationsByNameSet = true
+	}
+	cfg.RelationsByName, _ = flags.GetBool("relations-by-name")
 
 	if flags.Changed("log") {
 		cfg.logSet = true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -15,6 +15,7 @@ func TestDefaultFromEnv(t *testing.T) {
 	t.Setenv("TRACESQL_PASSWORD", "secret")
 	t.Setenv("TRACESQL_DATABASE", "trace")
 	t.Setenv("TRACESQL_NEW_IDS", "true")
+	t.Setenv("TRACESQL_RELATIONS_BY_NAME", "true")
 
 	cfg := config.Default()
 
@@ -35,6 +36,9 @@ func TestDefaultFromEnv(t *testing.T) {
 	}
 	if !cfg.NewIDs {
 		t.Fatalf("flag de novos IDs deveria estar true")
+	}
+	if !cfg.RelationsByName {
+		t.Fatalf("flag de relacoes por nome deveria estar true")
 	}
 }
 

--- a/internal/export/exporter.go
+++ b/internal/export/exporter.go
@@ -34,7 +34,7 @@ func Run(ctx context.Context, db *sql.DB, cfg config.Config) (string, error) {
 	cfg.Normalize()
 	cfg.EnsureDefaults()
 	logf := newTraceLogger(cfg.Log)
-	logf("iniciando export: source=%s target=%s table=%s column=%s record=%s new_ids=%t", cfg.Driver, cfg.OutputDriver, cfg.Table, cfg.Column, cfg.Record, cfg.NewIDs)
+	logf("iniciando export: source=%s target=%s table=%s column=%s record=%s new_ids=%t relations_by_name=%t", cfg.Driver, cfg.OutputDriver, cfg.Table, cfg.Column, cfg.Record, cfg.NewIDs, cfg.RelationsByName)
 
 	baseRows, err := queryRowsByValue(ctx, db, cfg.Driver, cfg.Table, cfg.Column, cfg.Record, logf)
 	if err != nil {
@@ -50,6 +50,11 @@ func Run(ctx context.Context, db *sql.DB, cfg config.Config) (string, error) {
 		return "", fmt.Errorf("descobrindo metadata: %w", err)
 	}
 	logf("metadata descoberta: %d tabelas e %d foreign keys", len(catalog.TableNames()), len(catalog.ForeignKeys))
+	if cfg.RelationsByName {
+		var inferred int
+		catalog, inferred = catalog.WithNameInferredForeignKeys()
+		logf("relações por nome habilitadas: %d relações inferidas (%d total)", inferred, len(catalog.ForeignKeys))
+	}
 
 	if tableMeta, ok := catalog.Table(cfg.Table); ok {
 		cfg.Table = tableMeta.Name

--- a/internal/export/exporter_related_test.go
+++ b/internal/export/exporter_related_test.go
@@ -169,6 +169,128 @@ func TestRunExportNewIDsComRelacoesNoDestinoPostgres(t *testing.T) {
 	)
 }
 
+func TestRunExportNaoInfereRelacoesPorNomePorPadrao(t *testing.T) {
+	db := openSQLiteTestDB(t)
+
+	mustExec(t, db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+	mustExec(t, db, "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, total INT)")
+	mustExec(t, db, "INSERT INTO users (id, name) VALUES (1, 'Alice')")
+	mustExec(t, db, "INSERT INTO orders (id, user_id, total) VALUES (10, 1, 99)")
+
+	cfg := config.Config{
+		Driver:       "sqlite",
+		OutputDriver: "sqlite",
+		DSN:          "unused",
+		Table:        "users",
+		Column:       "id",
+		Record:       "1",
+	}
+
+	sqlDump, err := Run(context.Background(), db, cfg)
+	if err != nil {
+		t.Fatalf("erro ao exportar sem inferência por nome: %v", err)
+	}
+
+	containsAll(t, sqlDump,
+		"CREATE TABLE IF NOT EXISTS `users`",
+		"INSERT INTO `users` (`id`, `name`) VALUES (1, 'Alice');",
+	)
+
+	if strings.Contains(sqlDump, "CREATE TABLE IF NOT EXISTS `orders`") || strings.Contains(sqlDump, "FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)") {
+		t.Fatalf("não deveria inferir relações por nome sem a flag: %s", sqlDump)
+	}
+}
+
+func TestRunExportRelacoesPorNomeSemForeignKey(t *testing.T) {
+	db := openSQLiteTestDB(t)
+
+	mustExec(t, db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+	mustExec(t, db, "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, total INT)")
+	mustExec(t, db, "CREATE TABLE order_items (id INTEGER PRIMARY KEY, order_id INTEGER, sku TEXT)")
+	mustExec(t, db, "INSERT INTO users (id, name) VALUES (1, 'Alice'), (2, 'Bob')")
+	mustExec(t, db, "INSERT INTO orders (id, user_id, total) VALUES (10, 1, 50), (11, 1, 70), (20, 2, 99)")
+	mustExec(t, db, "INSERT INTO order_items (id, order_id, sku) VALUES (100, 10, 'A-1'), (101, 11, 'A-2'), (200, 20, 'B-1')")
+
+	cfg := config.Config{
+		Driver:          "sqlite",
+		OutputDriver:    "postgres",
+		DSN:             "unused",
+		Table:           "users",
+		Column:          "id",
+		Record:          "1",
+		RelationsByName: true,
+	}
+
+	sqlDump, err := Run(context.Background(), db, cfg)
+	if err != nil {
+		t.Fatalf("erro ao exportar com relações por nome: %v", err)
+	}
+
+	containsAll(t, sqlDump,
+		`CREATE TABLE IF NOT EXISTS "users"`,
+		`CREATE TABLE IF NOT EXISTS "orders"`,
+		`CREATE TABLE IF NOT EXISTS "order_items"`,
+		`FOREIGN KEY ("user_id") REFERENCES "users" ("id")`,
+		`FOREIGN KEY ("order_id") REFERENCES "orders" ("id")`,
+		`INSERT INTO "users" ("id", "name") VALUES (1, 'Alice');`,
+		`INSERT INTO "orders" ("id", "user_id", "total") VALUES (10, 1, 50);`,
+		`INSERT INTO "orders" ("id", "user_id", "total") VALUES (11, 1, 70);`,
+		`INSERT INTO "order_items" ("id", "order_id", "sku") VALUES (100, 10, 'A-1');`,
+		`INSERT INTO "order_items" ("id", "order_id", "sku") VALUES (101, 11, 'A-2');`,
+	)
+
+	if strings.Contains(sqlDump, `'Bob'`) || strings.Contains(sqlDump, "(20, 2, 99)") || strings.Contains(sqlDump, "'B-1'") {
+		t.Fatalf("o dump não deveria incluir registros desconectados do grafo inicial: %s", sqlDump)
+	}
+
+	assertInOrder(t, sqlDump,
+		`CREATE TABLE IF NOT EXISTS "users"`,
+		`CREATE TABLE IF NOT EXISTS "orders"`,
+		`CREATE TABLE IF NOT EXISTS "order_items"`,
+		`INSERT INTO "users"`,
+		`INSERT INTO "orders"`,
+		`INSERT INTO "order_items"`,
+	)
+}
+
+func TestRunExportNewIDsComRelacoesPorNomeNoDestinoSQLite(t *testing.T) {
+	db := openSQLiteTestDB(t)
+
+	mustExec(t, db, "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+	mustExec(t, db, "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, total INT)")
+	mustExec(t, db, "CREATE TABLE order_items (id INTEGER PRIMARY KEY, order_id INTEGER, sku TEXT)")
+	mustExec(t, db, "INSERT INTO users (id, name) VALUES (1, 'Alice')")
+	mustExec(t, db, "INSERT INTO orders (id, user_id, total) VALUES (10, 1, 99)")
+	mustExec(t, db, "INSERT INTO order_items (id, order_id, sku) VALUES (100, 10, 'A-1')")
+
+	cfg := config.Config{
+		Driver:          "sqlite",
+		OutputDriver:    "sqlite",
+		DSN:             "unused",
+		Table:           "users",
+		Column:          "id",
+		Record:          "1",
+		NewIDs:          true,
+		RelationsByName: true,
+	}
+
+	sqlDump, err := Run(context.Background(), db, cfg)
+	if err != nil {
+		t.Fatalf("erro ao exportar com new_ids e relações por nome: %v", err)
+	}
+
+	containsAll(t, sqlDump,
+		"CREATE TEMP TABLE `__tracesql_map_users`",
+		"CREATE TEMP TABLE `__tracesql_map_orders`",
+		"CREATE TEMP TABLE `__tracesql_map_order_items`",
+		"INSERT INTO `users` (`name`) VALUES ('Alice');",
+		"INSERT INTO `__tracesql_map_users` (`old_id`, `new_id`) VALUES (1, last_insert_rowid());",
+		"INSERT INTO `orders` (`user_id`, `total`) VALUES ((SELECT `new_id` FROM `__tracesql_map_users` WHERE `old_id` = 1), 99);",
+		"INSERT INTO `__tracesql_map_orders` (`old_id`, `new_id`) VALUES (10, last_insert_rowid());",
+		"INSERT INTO `order_items` (`order_id`, `sku`) VALUES ((SELECT `new_id` FROM `__tracesql_map_orders` WHERE `old_id` = 10), 'A-1');",
+	)
+}
+
 func containsAll(t *testing.T, content string, snippets ...string) {
 	t.Helper()
 

--- a/internal/metadata/metadata.go
+++ b/internal/metadata/metadata.go
@@ -98,6 +98,99 @@ func (c Catalog) TableNames() []string {
 	return names
 }
 
+func (c Catalog) WithNameInferredForeignKeys() (Catalog, int) {
+	if len(c.tables) == 0 {
+		return c, 0
+	}
+
+	exactTables := make(map[string]string, len(c.tables))
+	aliasCandidates := map[string][]string{}
+	for _, table := range c.tables {
+		lowerName := strings.ToLower(table.Name)
+		exactTables[lowerName] = table.Name
+		for _, alias := range tableNameAliases(lowerName) {
+			aliasCandidates[alias] = appendUnique(aliasCandidates[alias], table.Name)
+		}
+	}
+
+	foreignKeys := append([]ForeignKey(nil), c.ForeignKeys...)
+	existing := map[string]struct{}{}
+	columnsWithRelations := map[string]struct{}{}
+	for _, fk := range foreignKeys {
+		existing[foreignKeyKey(fk)] = struct{}{}
+		columnsWithRelations[strings.ToLower(fk.Table)+"."+strings.ToLower(fk.Column)] = struct{}{}
+	}
+
+	added := 0
+	for _, tableName := range c.TableNames() {
+		table, ok := c.Table(tableName)
+		if !ok {
+			continue
+		}
+
+		for _, column := range table.Columns {
+			columnName := strings.ToLower(column.Name)
+			if !strings.HasSuffix(columnName, "_id") {
+				continue
+			}
+			if _, exists := columnsWithRelations[strings.ToLower(table.Name)+"."+columnName]; exists {
+				continue
+			}
+
+			refAlias := strings.TrimSuffix(columnName, "_id")
+			refTableName, ok := inferReferenceTable(refAlias, exactTables, aliasCandidates)
+			if !ok {
+				continue
+			}
+
+			refTable, ok := c.Table(refTableName)
+			if !ok || !hasPrimaryKeyColumn(refTable, "id") {
+				continue
+			}
+
+			fk := ForeignKey{
+				Table:     table.Name,
+				Column:    column.Name,
+				RefTable:  refTable.Name,
+				RefColumn: "id",
+			}
+			key := foreignKeyKey(fk)
+			if _, exists := existing[key]; exists {
+				continue
+			}
+
+			existing[key] = struct{}{}
+			columnsWithRelations[strings.ToLower(table.Name)+"."+columnName] = struct{}{}
+			foreignKeys = append(foreignKeys, fk)
+			added++
+		}
+	}
+
+	if added == 0 {
+		return c, 0
+	}
+
+	sort.Slice(foreignKeys, func(i, j int) bool {
+		left := foreignKeys[i]
+		right := foreignKeys[j]
+		if left.Table != right.Table {
+			return left.Table < right.Table
+		}
+		if left.Column != right.Column {
+			return left.Column < right.Column
+		}
+		if left.RefTable != right.RefTable {
+			return left.RefTable < right.RefTable
+		}
+		return left.RefColumn < right.RefColumn
+	})
+
+	return Catalog{
+		tables:      c.tables,
+		ForeignKeys: foreignKeys,
+	}, added
+}
+
 func (t Table) PrimaryKeyColumns() []string {
 	var cols []string
 	for _, col := range t.Columns {
@@ -106,6 +199,51 @@ func (t Table) PrimaryKeyColumns() []string {
 		}
 	}
 	return cols
+}
+
+func hasPrimaryKeyColumn(table Table, columnName string) bool {
+	for _, column := range table.Columns {
+		if strings.EqualFold(column.Name, columnName) && column.PrimaryKey {
+			return true
+		}
+	}
+	return false
+}
+
+func inferReferenceTable(alias string, exactTables map[string]string, aliasCandidates map[string][]string) (string, bool) {
+	if tableName, ok := exactTables[alias]; ok {
+		return tableName, true
+	}
+
+	candidates := aliasCandidates[alias]
+	if len(candidates) != 1 {
+		return "", false
+	}
+	return candidates[0], true
+}
+
+func tableNameAliases(name string) []string {
+	aliases := []string{name}
+	switch {
+	case strings.HasSuffix(name, "ies") && len(name) > 3:
+		aliases = append(aliases, name[:len(name)-3]+"y")
+	case strings.HasSuffix(name, "s") && len(name) > 1:
+		aliases = append(aliases, strings.TrimSuffix(name, "s"))
+	}
+	return aliases
+}
+
+func appendUnique(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func foreignKeyKey(fk ForeignKey) string {
+	return strings.ToLower(fk.Table) + "|" + strings.ToLower(fk.Column) + "|" + strings.ToLower(fk.RefTable) + "|" + strings.ToLower(fk.RefColumn)
 }
 
 type inspector interface {

--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -123,3 +123,54 @@ func TestDiscoverMySQL(t *testing.T) {
 		t.Fatalf("expectativas não atendidas: %v", err)
 	}
 }
+
+func TestWithNameInferredForeignKeys(t *testing.T) {
+	catalog := Catalog{
+		tables: map[string]Table{
+			"users": {
+				Name: "users",
+				Columns: []Column{
+					{Name: "id", PrimaryKey: true},
+					{Name: "name"},
+				},
+			},
+			"orders": {
+				Name: "orders",
+				Columns: []Column{
+					{Name: "id", PrimaryKey: true},
+					{Name: "user_id"},
+					{Name: "total"},
+				},
+			},
+			"audit_logs": {
+				Name: "audit_logs",
+				Columns: []Column{
+					{Name: "id", PrimaryKey: true},
+					{Name: "user_id"},
+				},
+			},
+		},
+		ForeignKeys: []ForeignKey{
+			{Table: "audit_logs", Column: "user_id", RefTable: "users", RefColumn: "id"},
+		},
+	}
+
+	updated, inferred := catalog.WithNameInferredForeignKeys()
+	if inferred != 1 {
+		t.Fatalf("esperava 1 relação inferida, obtive %d", inferred)
+	}
+	if len(updated.ForeignKeys) != 2 {
+		t.Fatalf("esperava 2 relações no total, obtive %+v", updated.ForeignKeys)
+	}
+
+	expected := ForeignKey{Table: "orders", Column: "user_id", RefTable: "users", RefColumn: "id"}
+	found := false
+	for _, fk := range updated.ForeignKeys {
+		if fk == expected {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("relação inferida não encontrada: %+v", updated.ForeignKeys)
+	}
+}

--- a/internal/prompt/prompt_test.go
+++ b/internal/prompt/prompt_test.go
@@ -24,6 +24,7 @@ func TestFillMissingNaoPerguntaCamposJaInformadosPorFlag(t *testing.T) {
 		"--column", "id",
 		"--record", "1001",
 		"--new-ids=false",
+		"--relations-by-name",
 		"--output-driver", "sqlite",
 		"--log",
 	}
@@ -50,6 +51,9 @@ func TestFillMissingNaoPerguntaCamposJaInformadosPorFlag(t *testing.T) {
 	}
 	if cfg.NewIDs {
 		t.Fatalf("new_ids deveria permanecer false")
+	}
+	if !cfg.RelationsByName {
+		t.Fatalf("relations_by_name deveria permanecer true")
 	}
 	if !cfg.Log {
 		t.Fatalf("log deveria permanecer true")


### PR DESCRIPTION
## O que mudou
- adiciona a flag `--relations-by-name` e a env `TRACESQL_RELATIONS_BY_NAME`
- infere relacionamentos pelo padrão `[tabela]_id` sem substituir foreign keys reais já existentes
- reutiliza o mesmo fluxo de exportação para coleta do grafo, ordenação das tabelas e remapeamento com `--new-ids`
- atualiza a documentação e amplia a cobertura de testes para o modo padrão, o modo por nome e o fluxo com novos IDs

## Por que mudou
Alguns bancos usados com o TraceSQL não possuem foreign keys declaradas, mesmo quando as tabelas seguem um padrão de nome consistente como `usuario_id` ou `order_id`. Nesses casos, o exportador não conseguia montar o grafo relacional completo.

## Impacto
- o comportamento atual continua igual por padrão
- quando a nova opção é habilitada, o TraceSQL passa a seguir relações inferidas por nome e também gera as referências no schema de saída
- o fluxo de manter IDs existentes ou criar novos IDs continua funcionando para essas relações inferidas

## Validação
- `go test ./...`
