### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync_labels.yml
+++ b/.github/workflows/sync_labels.yml
@@ -7,6 +7,9 @@ on:
 jobs:
 
   sync_labels:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/Felipe-Cavalca/TraceSQL/security/code-scanning/1](https://github.com/Felipe-Cavalca/TraceSQL/security/code-scanning/1)

In general, to fix this problem you add a `permissions` block either at the top level of the workflow (affecting all jobs) or inside the specific job, granting only the scopes required. This prevents `GITHUB_TOKEN` from inheriting potentially broad default permissions.

For this specific workflow, we should add a `permissions` block under the `sync_labels` job. The job checks out the repository (`actions/checkout`) and then synchronizes labels (`micnncim/action-label-syncer`). `checkout` only needs `contents: read`. The label sync action updates repository labels, which are part of the issues/labels domain, so it needs `issues: write`. We therefore set:

```yaml
permissions:
  contents: read
  issues: write
```

We will insert this block directly under `sync_labels:` and above `runs-on: ubuntu-latest` in `.github/workflows/sync_labels.yml`. No imports or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
