### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tag_on_merge.yml
+++ b/.github/workflows/tag_on_merge.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: write
+  actions: write
+
 jobs:
   create_tag_and_draft_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Felipe-Cavalca/TraceSQL/security/code-scanning/3](https://github.com/Felipe-Cavalca/TraceSQL/security/code-scanning/3)

In general, the fix is to add an explicit `permissions` block at the root of the workflow (or per job) that grants only the scopes actually required by the jobs: read access where possible, and write access only where necessary (e.g., for creating tags, dispatching repository events, updating releases, and pushing branches).

The best minimal fix without changing functionality is to add a single `permissions` block at the top level of `.github/workflows/tag_on_merge.yml`, just under the `on:` section. All jobs in this workflow perform Git operations and release management, which rely on `contents: write` (for creating tags and pushing branches) and `actions: write` or `contents: write`/`metadata` for `repository_dispatch` events and release updates. We can conservatively set `contents: write` and `actions: write` at the workflow level so every job that needs to write can continue to function, while explicitly documenting and constraining the token instead of inheriting possibly broader defaults. No additional imports or code changes are needed; only YAML configuration is updated.

Concretely:
- Edit `.github/workflows/tag_on_merge.yml`.
- Insert a `permissions:` block between the `on:` block (lines 3–5) and `jobs:` (line 7).
- Set:
  - `contents: write` (needed for creating tags, pushing branches, and updating releases).
  - `actions: write` (needed for `createDispatchEvent` / repository dispatch events).
This ensures all jobs use these explicit permissions and nothing broader.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
