### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tag_on_merge.yml
+++ b/.github/workflows/tag_on_merge.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   create_tag_and_draft_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Felipe-Cavalca/TraceSQL/security/code-scanning/5](https://github.com/Felipe-Cavalca/TraceSQL/security/code-scanning/5)

In general, the fix is to add an explicit `permissions` block at the workflow root (applies to all jobs) or per job, granting only the minimum scopes required. This ensures the `GITHUB_TOKEN` cannot exceed these permissions, even if repo/org defaults are broad.

For this workflow, different jobs need different permissions:

- `create_tag_and_draft_release`:
  - Uses `actions/checkout` to push tags and uses `github-script` to call `repos.createDispatchEvent`.
  - Needs to read contents and write tags/refs and repository dispatch events.
  - Minimal:  
    - `contents: write` (to create tags and push).  
    - `repository-projects: read` is not needed; we only see repos API.  
    - For `createDispatchEvent`, GitHub’s docs indicate the `contents` scope is sufficient on the `GITHUB_TOKEN`, so `contents: write` already covers it. No extra permission key for dispatch is required.

- `update_release_draft` (Release Drafter):
  - Reads PRs, commits, and creates/updates a draft release.
  - Needs:  
    - `contents: read` (read commits/tags).  
    - `pull-requests: read` (read PR metadata).  
    - `contents: write` and/or `contents: write` + `metadata` for creating/updating releases; GitHub treats releases under `contents`. To be safe and minimal, `contents: write` is sufficient.

- `publish_release`:
  - Lists and updates releases via `github.rest.repos.listReleases` and `updateRelease`.
  - Needs:  
    - `contents: write` (for releases).  
    - `contents: read` is implied by `contents: write`.

- `update_branch_release`:
  - Checks out `main`, creates/updates branch `latest-release`, and pushes.
  - Needs:  
    - `contents: write` (for branch updates).

Because every job requires `contents: write`, the simplest and least intrusive change is to add a single workflow-level `permissions` block granting `contents: write` (and optionally `pull-requests: read` which Release Drafter typically uses). This avoids broader defaults while preserving current behavior.

Concretely:

- In `.github/workflows/tag_on_merge.yml`, add a root-level `permissions:` block right after the `name:` or `on:` section, with:
  - `contents: write`
  - `pull-requests: read`

No imports or external dependencies are needed; this is purely YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
