### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tag_on_merge.yml
+++ b/.github/workflows/tag_on_merge.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [closed]
 
+permissions:
+  contents: write
+
 jobs:
   create_tag_and_draft_release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Felipe-Cavalca/TraceSQL/security/code-scanning/6](https://github.com/Felipe-Cavalca/TraceSQL/security/code-scanning/6)

In general, the fix is to add an explicit `permissions:` block to the workflow (either at the top level or for each job) that grants only the scopes actually needed. Jobs that only read repository data should get `contents: read`; jobs that must write to repository contents, releases, or dispatch events need corresponding `write` scopes. This both documents and enforces least privilege for the GITHUB_TOKEN that GitHub Actions automatically injects.

For this specific workflow, we can add a single top-level `permissions:` block after the `on:` section, applying to all jobs. Based on the shown steps:
- `create_tag_and_draft_release` uses `github.rest.repos.createDispatchEvent`, which requires `contents: write` (repository dispatch is tied to repository write).
- `update_release_draft` uses `release-drafter`, which needs to create/update releases, requiring `contents: write`.
- `publish_release` lists and updates releases, also requiring `contents: write`.
- `update_branch_release` checks out the repo and pushes a branch, requiring `contents: write`.

Since all shown jobs perform write operations, the minimal safe setting for this workflow is `permissions: contents: write`. If you wanted finer-grained control per job, you could override at each job, but that would be more invasive; adding one top-level block preserves existing behavior while making permissions explicit. The only change needed is to insert this `permissions:` mapping into `.github/workflows/tag_on_merge.yml`; no imports or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
