### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tag_on_merge.yml
+++ b/.github/workflows/tag_on_merge.yml
@@ -1,5 +1,8 @@
 name: Tag on merge
 
+permissions:
+  contents: write
+
 on:
   pull_request:
     types: [closed]


### PR DESCRIPTION
Potential fix for [https://github.com/Felipe-Cavalca/TraceSQL/security/code-scanning/4](https://github.com/Felipe-Cavalca/TraceSQL/security/code-scanning/4)

In general, the fix is to add an explicit `permissions:` block specifying the minimal scopes needed. This can be done at the workflow root (applies to all jobs) and optionally overridden per job if some jobs need more (e.g., write) while others only need read.

For this workflow, we should add a root-level `permissions:` block with conservative defaults (`contents: read`) and then grant write permissions only to the jobs that actually perform write operations:

- `create_tag_and_draft_release`: uses `actions/checkout` (needs `contents: read`) and `github-script` to create a repository dispatch event (needs `contents: write` or `actions: write` depending on the API, but the `repository_dispatch` endpoint is guarded by `contents`/repo write). It also presumably creates tags and a draft release in the omitted section, which also requires repo write permissions.
- `update_release_draft`: `release-drafter` needs to read PRs/issues and create/update a draft release (requires `contents: write` and `pull-requests: read` at least, but `GITHUB_TOKEN` with `contents: write` is sufficient for releases; release-drafter docs recommend `contents: write`).
- `publish_release`: uses `github-script` to list and update releases (needs `contents: write`).
- `update_branch_release`: checks out and pushes a branch (needs `contents: write`).

Given that all jobs here perform or depend on write operations, the simplest least-surprising change without altering behavior is:

- Add a single root `permissions:` granting `contents: write` (and optionally `pull-requests: read` and `issues: read` if you want to be explicit). This is already narrower than the legacy read‑write default that also includes other scopes like `actions: write`, `checks: write`, etc.

Concretely:

- In `.github/workflows/tag_on_merge.yml`, insert a `permissions:` block after the `name:` line (before `on:`). Example:

```yaml
name: Tag on merge

permissions:
  contents: write

on:
  pull_request:
    types: [closed]
```

No additional imports or definitions are needed; only YAML structure changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
